### PR TITLE
Fingerprint: Stop Authentication

### DIFF
--- a/services/core/java/com/android/server/fingerprint/AuthenticationClient.java
+++ b/services/core/java/com/android/server/fingerprint/AuthenticationClient.java
@@ -81,7 +81,6 @@ public abstract class AuthenticationClient extends ClientMonitor {
             // allow system-defined limit of number of attempts before giving up
             boolean inLockoutMode =  handleFailedAttempt();
             // send lockout event in case driver doesn't enforce it.
-            stop(true);
             if (inLockoutMode) {
                 try {
                     Slog.w(TAG, "Forcing lockout (fp driver code should do this!)");


### PR DESCRIPTION
When finger is not authenticated / doesn't recognized , it doesn't allow to unlock the phone via fingerprint anymore , it only unlock via pattern or pin. So It may be fix the issue. Please Review it.