### PR TITLE
SEEMP: Adding auth framework for outgoing SMS messages.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -472,6 +472,8 @@ LOCAL_SRC_FILES += \
 	packages/services/Proxy/com/android/net/IProxyPortListener.aidl \
 	core/java/android/service/quicksettings/IQSService.aidl \
 	core/java/android/service/quicksettings/IQSTileService.aidl \
+	telephony/java/com/android/internal/telephony/ISmsSecurityService.aidl \
+	telephony/java/com/android/internal/telephony/ISmsSecurityAgent.aidl \
 
 # The following are native binders that need to go with the native component
 # at system/update_engine/binder_bindings/. Use relative path to refer to them.

--- a/core/res/AndroidManifest.xml
+++ b/core/res/AndroidManifest.xml
@@ -1115,6 +1115,11 @@
     <permission android:name="android.permission.MODIFY_CELL_BROADCASTS"
                 android:protectionLevel="signature|privileged" />
 
+    <!-- Allows an application to authorize outgoing SMS messages.
+         @hide -->
+    <permission android:name="android.permission.AUTHORIZE_OUTGOING_SMS"
+                android:protectionLevel="signature" />
+
     <!-- =============================================================== -->
     <!-- Permissions for setting the device alarm                        -->
     <!-- =============================================================== -->

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2952,6 +2952,12 @@
     <!-- Whether notify fingerprint client of successful cancelled authentication -->
     <bool name="config_notifyClientOnFingerprintCancelSuccess">false</bool>
 
+    <!-- The duration (in milliseconds) for the outgoing sms authorization request to timeout.-->
+    <integer name="config_sms_authorization_timeout_ms">0</integer>
+
+    <!-- Enable sms authorization framework-->
+    <bool name="config_sms_authorization_enabled">false</bool>
+
     <!-- If enabled, capacitive keys will only light up when pressed.
          Otherwise, the buttons will light up whenever the user interacts with the device -->
     <bool name="config_buttonLightOnKeypressOnly">false</bool>

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -2847,4 +2847,7 @@
   <java-symbol type="bool" name="use_lock_pattern_drawable" />
   <java-symbol type="drawable" name="lockscreen_notselected" />
   <java-symbol type="drawable" name="lockscreen_selected" />
+
+  <java-symbol type="integer" name="config_sms_authorization_timeout_ms" />
+  <java-symbol type="bool" name="config_sms_authorization_enabled" />
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
@@ -1818,14 +1818,9 @@ public class KeyguardViewMediator extends SystemUI {
                 }
             }
 
-            boolean wakeAndUnlocking = mWakeAndUnlocking;
             mWakeAndUnlocking = false;
             setShowingLocked(false);
-            if (wakeAndUnlocking) {
-                mStatusBarKeyguardViewManager.hideNoAnimation();
-            } else {
-                mStatusBarKeyguardViewManager.hide(startTime, fadeoutDuration);
-            }
+            mStatusBarKeyguardViewManager.hide(startTime, fadeoutDuration);
             resetKeyguardDonePendingLocked();
             mHideAnimationRun = false;
             updateActivityLockScreenState();

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/FingerprintUnlockController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/FingerprintUnlockController.java
@@ -213,6 +213,7 @@ public class FingerprintUnlockController extends KeyguardUpdateMonitorCallback {
                 mStatusBarWindowManager.setStatusBarFocusable(false);
                 mDozeScrimController.abortPulsing();
                 mKeyguardViewMediator.onWakeAndUnlocking();
+                mScrimController.setWakeAndUnlocking();
                 if (mPhoneStatusBar.getNavigationBarView() != null) {
                     mPhoneStatusBar.getNavigationBarView().setWakeAndUnlocking(true);
                 }
@@ -222,7 +223,9 @@ public class FingerprintUnlockController extends KeyguardUpdateMonitorCallback {
             case MODE_NONE:
                 break;
         }
-        mStatusBarWindowManager.setForceDozeBrightness(false);
+        if (mMode != MODE_WAKE_AND_UNLOCK_PULSING) {
+            mStatusBarWindowManager.setForceDozeBrightness(false);
+        }
         mPhoneStatusBar.notifyFpAuthModeChanged();
         Trace.endSection();
     }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NavigationBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NavigationBarView.java
@@ -440,7 +440,7 @@ public class NavigationBarView extends LinearLayout implements TunerService.Tuna
     }
 
     public void setWakeAndUnlocking(boolean wakeAndUnlocking) {
-        setUseFadingAnimations(!wakeAndUnlocking);
+        setUseFadingAnimations(wakeAndUnlocking);
         mWakeAndUnlocking = wakeAndUnlocking;
         updateLayoutTransitionsEnabled();
     }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -2733,10 +2733,9 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
                 if (DEBUG_MEDIA) {
                     Log.v(TAG, "DEBUG_MEDIA: Fading out album artwork");
                 }
-                int fpMode = mFingerprintUnlockController.getMode();
-                if (fpMode == FingerprintUnlockController.MODE_WAKE_AND_UNLOCK_PULSING ||
-                        fpMode == FingerprintUnlockController.MODE_WAKE_AND_UNLOCK ||
-                        hideBecauseOccluded) {
+                if (mFingerprintUnlockController.getMode()
+                        == FingerprintUnlockController.MODE_WAKE_AND_UNLOCK_PULSING
+                        || hideBecauseOccluded) {
 
                     // We are unlocking directly - no animation!
                     mBackdrop.setVisibility(View.GONE);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarKeyguardViewManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarKeyguardViewManager.java
@@ -396,20 +396,6 @@ public class StatusBarKeyguardViewManager implements RemoteInputController.Callb
         mBouncer.hide(true /* destroyView */);
     }
 
-    public void hideNoAnimation() {
-        mShowing = false;
-        mPhoneStatusBar.setKeyguardFadingAway(SystemClock.uptimeMillis(), 0, 0);
-        mPhoneStatusBar.hideKeyguard();
-        mPhoneStatusBar.finishKeyguardFadingAway();
-        mStatusBarWindowManager.setKeyguardShowing(false);
-        mBouncer.hide(true /* destroyView */);
-        mViewMediatorCallback.keyguardGone();
-        mFingerprintUnlockController.finishKeyguardFadingAway();
-        updateStates();
-        WindowManagerGlobal.getInstance().trimMemory(
-                ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN);
-    }
-
     private void animateScrimControllerKeyguardFadingOut(long delay, long duration,
             boolean skipFirstFrame) {
         animateScrimControllerKeyguardFadingOut(delay, duration, null /* endRunnable */,

--- a/telephony/java/com/android/internal/telephony/ISmsSecurityAgent.aidl
+++ b/telephony/java/com/android/internal/telephony/ISmsSecurityAgent.aidl
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.android.internal.telephony;
+
+import com.android.internal.telephony.SmsAuthorizationRequest;
+
+/**
+ * ISmsSecurityAgent enhances the security of outgoing SMS messages by allowing trusted system
+ * components to inspect and authorize or reject outgoing SMS messages.
+ *
+ * @hide
+ **/
+interface ISmsSecurityAgent {
+    /**
+     * Called when a SMS message is queued for dispatch allowing a registered
+     * agent to decide on whether to accept/reject the request to send an SMS message.
+     * <b>Unless the agent rejects the request within the OEM specific timeout, the SMS
+     * will be sent.</b>
+     * @param request the object containing information regarding the message and
+     *                through which the agent can accept/reject the request.
+     */
+    void onAuthorize(in SmsAuthorizationRequest request);
+
+}

--- a/telephony/java/com/android/internal/telephony/ISmsSecurityService.aidl
+++ b/telephony/java/com/android/internal/telephony/ISmsSecurityService.aidl
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2016, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.android.internal.telephony;
+
+import com.android.internal.telephony.ISmsSecurityAgent;
+import com.android.internal.telephony.SmsAuthorizationRequest;
+
+/**
+ * ISmsSecurityService exposes a service that monitors the dispatch of outgoing SMS messages
+ * and notifies a registered ISmsSecurityAgent in order to authorize or reject the dispatch
+ * of each outgoing SMS message.
+ *
+ * @hide
+ */
+interface ISmsSecurityService {
+    /**
+     * Registers an agent in order to receive requests for outgoing SMS messages on which
+     * it can accept or reject the request for the dispatch of each SMS message.
+     * <b>Only one agent can be registered at one time.</b>
+     * @param agent the agent to be registered.
+     * @return true if the registration succeeds, false otherwise.
+     */
+    boolean register(in ISmsSecurityAgent agent);
+
+    /**
+     * Unregisters the previously registered agent and causes the security
+     * service to no longer rely on the agent for a decision regarding
+     * successive SMS messages being dispatched allowing all successive messages to be dispatched.
+     *
+     * @param agent the agent to be unregistered.
+     * @return true if the unregistration succeeds, false otherwise.
+     */
+    boolean unregister(in ISmsSecurityAgent agent);
+
+    /**
+     * Allows the registered ISmsSecurityAgent implementation to asynchronously send a response
+     * on whether it will accept/reject the dispatch of the SMS message.
+     * <b>If the agent responds after the OEM defined timeout it may not be able to
+     * interfere on whether the SMS was sent or not.</b>
+     * @param request the request related to an outgoing SMS message to accept/reject.
+     * @param accepted true to accept, false to reject.
+     * return true if the response took effect, false if a response has already been sent for this
+     * request or an OEM specific timeout already happened.
+     */
+    boolean sendResponse(in SmsAuthorizationRequest request, boolean authorized);
+}

--- a/telephony/java/com/android/internal/telephony/SmsAuthorizationRequest.aidl
+++ b/telephony/java/com/android/internal/telephony/SmsAuthorizationRequest.aidl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.android.internal.telephony;
+
+/** @hide */
+parcelable SmsAuthorizationRequest;

--- a/telephony/java/com/android/internal/telephony/SmsAuthorizationRequest.java
+++ b/telephony/java/com/android/internal/telephony/SmsAuthorizationRequest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2016, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.android.internal.telephony;
+
+import android.os.IBinder;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.os.RemoteException;
+
+/**
+ * This class represents a request from the {@link ISmsSecurityService} to trusted parties
+ * in order to allow third party components to participate in the decision process to accept
+ * or reject a request to send an SMS message.
+ *
+ * @hide
+ */
+public class SmsAuthorizationRequest implements Parcelable {
+
+    private final ISmsSecurityService service;
+
+    private final IBinder token;
+
+    public final String packageName;
+
+    public final String destinationAddress;
+
+    public final String message;
+
+    public SmsAuthorizationRequest(final Parcel source) {
+        this.service = ISmsSecurityService.Stub.asInterface(source.readStrongBinder());
+        this.token = source.readStrongBinder();
+        this.packageName = source.readString();
+        this.destinationAddress = source.readString();
+        this.message = source.readString();
+    }
+
+    public SmsAuthorizationRequest(final ISmsSecurityService service,
+            final IBinder binderToken,
+            final String packageName,
+            final String destinationAddress,
+            final String message) {
+        this.service = service;
+        this.token = binderToken;
+        this.packageName = packageName;
+        this.destinationAddress = destinationAddress;
+        this.message = message;
+    }
+
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        dest.writeStrongBinder(service.asBinder());
+        dest.writeStrongBinder(token);
+        dest.writeString(packageName);
+        dest.writeString(destinationAddress);
+        dest.writeString(message);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static Parcelable.Creator<SmsAuthorizationRequest> CREATOR =
+            new Creator<SmsAuthorizationRequest>() {
+        @Override
+        public SmsAuthorizationRequest[] newArray(final int size) {
+            return new SmsAuthorizationRequest[size];
+        }
+
+        @Override
+        public SmsAuthorizationRequest createFromParcel(final Parcel source) {
+            return new SmsAuthorizationRequest(source);
+        }
+    };
+
+    public void accept() throws RemoteException{
+        service.sendResponse(this, true);
+    }
+
+    public void reject() throws RemoteException {
+        service.sendResponse(this, false);
+    }
+
+    public IBinder getToken() {
+        return token;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("[%s] (%s) # %s",
+                this.packageName,
+                this.destinationAddress,
+                this.message);
+    }
+}


### PR DESCRIPTION
This change adds the APIs required to register an authorization agent
in order to allow/reject outgoing SMS messages and the core service
that implements the sms security model.