### PR TITLE
FontService: fix null object reference

### DIFF
--- a/services/core/java/com/android/server/FontService.java
+++ b/services/core/java/com/android/server/FontService.java
@@ -263,6 +263,7 @@ public class FontService extends IFontService.Stub {
     private void processFontPackage(String packageName) {
         List<FontInfo> infoList = new ArrayList<FontInfo>();
         Context appContext = getAppContext(packageName);
+        if (appContext == null) return;
         AssetManager am = appContext.getAssets();
         List<String> fontZips = getFontsFromPackage(packageName);
         File packageFontPreviewDir = new File(SYSTEM_THEME_PREVIEW_CACHE_DIR, packageName);


### PR DESCRIPTION
E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.res.AssetManager android.content.Context.getAssets()' on a null object reference