### PR TITLE
StatusBar: add missing import for ContentObserver

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
@@ -71,6 +71,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.UserInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.database.ContentObserver;
 import android.graphics.Bitmap;
 import android.graphics.Point;
 import android.graphics.PointF;


### PR DESCRIPTION
It was missed in https://github.com/crdroidandroid/android_frameworks_base/commit/9c0b96c42a44ff22dc93e53d17f56e1cc2c0fa22

Test: SystemUI compiles successfully