### PR TITLE
Add Flashlight blink on incoming calls [1/3]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -4656,6 +4656,16 @@ public final class Settings {
         public static final String RECENTS_ICON_PACK = "recents_icon_pack";
 
         /**
+         * Whether to blink flashlight for incoming calls
+         * 0 = Disabled (Default)
+         * 1 = Blink flashlight only in Ringer mode
+         * 2 = Blink flashlight only in DND mode
+         * 3 = Blink flashlight always regardless of ringer mode
+         * @hide
+         */
+        public static final String FLASHLIGHT_ON_CALL = "flashlight_on_call";
+
+        /**
          * Settings to backup. This is here so that it's in the same place as the settings
          * keys and easy to update.
          *


### PR DESCRIPTION
- There are tons of apps out there on playstore which replicate the same
  iOS behaviour. Let's just add it in system keeping it disabled by default.

Change-Id: I43f22939c9377bf23adaa4bb2bbfdfc2bde722f1
Signed-off-by: PMS22 <prathams99@rediff.com>
Signed-off-by: KillerDroid96 <mkeller96@gmail.com>