### PR TITLE
SystemUI: StatusBar icons: tighten things and conserve space

### DIFF
--- a/packages/SystemUI/res/layout/mobile_signal_group.xml
+++ b/packages/SystemUI/res/layout/mobile_signal_group.xml
@@ -34,14 +34,14 @@
             android:layout_width="wrap_content"
             android:src="@drawable/ic_activity_down"
             android:visibility="gone"
-            android:paddingEnd="2dp"
+            android:paddingEnd="1dp"
             />
         <ImageView
             android:id="@+id/mobile_out"
             android:layout_height="wrap_content"
             android:layout_width="wrap_content"
             android:src="@drawable/ic_activity_up"
-            android:paddingEnd="2dp"
+            android:paddingEnd="1dp"
             android:visibility="gone"
             />
     </FrameLayout>
@@ -51,7 +51,7 @@
         android:layout_width="wrap_content"
         android:layout_gravity="center_vertical"
         android:paddingStart="1dp"
-        android:paddingEnd="2dp"
+        android:paddingEnd="1dp"
         android:visibility="gone" />
     <Space
         android:id="@+id/mobile_roaming_space"

--- a/packages/SystemUI/res/layout/signal_cluster_view.xml
+++ b/packages/SystemUI/res/layout/signal_cluster_view.xml
@@ -30,7 +30,7 @@
         android:id="@+id/vpn"
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"
-        android:paddingEnd="6dp"
+        android:paddingEnd="4dp"
         android:src="@drawable/stat_sys_vpn_ic"
         android:tint="@color/background_protect_secondary"
         android:contentDescription="@string/accessibility_vpn_on"
@@ -63,14 +63,14 @@
             android:layout_width="wrap_content"
             android:src="@drawable/ic_activity_down"
             android:visibility="gone"
-            android:paddingEnd="2dp"
+            android:paddingEnd="1dp"
             />
         <ImageView
             android:id="@+id/wifi_out"
             android:layout_height="wrap_content"
             android:layout_width="wrap_content"
             android:src="@drawable/ic_activity_up"
-            android:paddingEnd="2dp"
+            android:paddingEnd="1dp"
             android:visibility="gone"
             />
     </FrameLayout>
@@ -101,7 +101,7 @@
     <View
         android:id="@+id/wifi_signal_spacer"
         android:layout_width="@dimen/status_bar_wifi_signal_spacer_width"
-        android:layout_height="4dp"
+        android:layout_height="3dp"
         android:visibility="gone"
         />
     <ViewStub
@@ -118,7 +118,7 @@
     <View
         android:id="@+id/wifi_airplane_spacer"
         android:layout_width="@dimen/status_bar_airplane_spacer_width"
-        android:layout_height="4dp"
+        android:layout_height="3dp"
         android:visibility="gone"
         />
     <ImageView

--- a/packages/SystemUI/res/layout/status_bar_alarm_group.xml
+++ b/packages/SystemUI/res/layout/status_bar_alarm_group.xml
@@ -20,7 +20,7 @@
     android:id="@+id/date_time_alarm_group"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:padding="4dp"
+    android:padding="3dp"
     android:gravity="center_vertical"
     android:orientation="horizontal"
     android:background="?android:attr/selectableItemBackground">

--- a/packages/SystemUI/res/layout/status_bar_mobile_signal_group.xml
+++ b/packages/SystemUI/res/layout/status_bar_mobile_signal_group.xml
@@ -52,14 +52,16 @@
                 android:layout_width="wrap_content"
                 android:src="@drawable/ic_activity_down"
                 android:visibility="gone"
-                android:paddingEnd="2dp"
+                android:paddingStart="1dp"
+                android:paddingEnd="1dp"
             />
             <ImageView
                 android:id="@+id/mobile_out"
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"
                 android:src="@drawable/ic_activity_up"
-                android:paddingEnd="2dp"
+                android:paddingStart="1dp"
+                android:paddingEnd="1dp"
                 android:visibility="gone"
             />
         </FrameLayout>
@@ -68,6 +70,7 @@
             android:layout_height="wrap_content"
             android:layout_width="wrap_content"
             android:layout_gravity="center_vertical"
+            android:paddingStart="1dp"
             android:paddingEnd="1dp"
             android:visibility="gone" />
         <Space
@@ -84,6 +87,7 @@
                 android:id="@+id/mobile_signal"
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"
+                android:paddingStart="1dp"
                 systemui:hasOverlappingRendering="false"
             />
             <ImageView

--- a/packages/SystemUI/res/layout/status_bar_wifi_group.xml
+++ b/packages/SystemUI/res/layout/status_bar_wifi_group.xml
@@ -29,7 +29,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:gravity="center_vertical"
-        android:layout_marginStart="2.5dp"
+        android:layout_marginStart="1.5dp"
     >
         <FrameLayout
                 android:id="@+id/inout_container"
@@ -42,14 +42,14 @@
                 android:layout_width="wrap_content"
                 android:src="@drawable/ic_activity_down"
                 android:visibility="gone"
-                android:paddingEnd="2dp"
+                android:paddingEnd="1dp"
             />
             <ImageView
                 android:id="@+id/wifi_out"
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"
                 android:src="@drawable/ic_activity_up"
-                android:paddingEnd="2dp"
+                android:paddingEnd="1dp"
                 android:visibility="gone"
             />
         </FrameLayout>
@@ -68,7 +68,7 @@
         <View
             android:id="@+id/wifi_signal_spacer"
             android:layout_width="@dimen/status_bar_wifi_signal_spacer_width"
-            android:layout_height="4dp"
+            android:layout_height="3dp"
             android:visibility="gone" />
 
         <!-- Looks like CarStatusBar uses this... -->
@@ -81,7 +81,7 @@
         <View
             android:id="@+id/wifi_airplane_spacer"
             android:layout_width="@dimen/status_bar_airplane_spacer_width"
-            android:layout_height="4dp"
+            android:layout_height="3dp"
             android:visibility="gone"
         />
     </com.android.keyguard.AlphaOptimizedLinearLayout>

--- a/packages/SystemUI/res/values/dimens.xml
+++ b/packages/SystemUI/res/values/dimens.xml
@@ -55,10 +55,10 @@
     <dimen name="status_bar_left_clock_end_padding">7dp</dimen>
 
     <!-- Spacing after the wifi signals that is present if there are any icons following it. -->
-    <dimen name="status_bar_wifi_signal_spacer_width">4dp</dimen>
+    <dimen name="status_bar_wifi_signal_spacer_width">3dp</dimen>
 
     <!-- Spacing before the airplane mode icon if there are any icons preceding it. -->
-    <dimen name="status_bar_airplane_spacer_width">4dp</dimen>
+    <dimen name="status_bar_airplane_spacer_width">3dp</dimen>
 
     <!-- The amount to scale each of the status bar icons by. A value of 1 means no scaling. -->
     <item name="status_bar_icon_scale_factor" format="float" type="dimen">1.0</item>
@@ -72,10 +72,10 @@
     <dimen name="max_notification_fadeout_height">100dp</dimen>
 
     <!-- End margin for the RSSI status icon of a device connected via bluetooth. -->
-    <dimen name="status_bar_connected_device_signal_margin_end">16dp</dimen>
+    <dimen name="status_bar_connected_device_signal_margin_end">14dp</dimen>
 
     <!-- The size of a bluetooth indicator icon that displays next to the RSSI status icon. -->
-    <dimen name="status_bar_connected_device_bt_indicator_size">17dp</dimen>
+    <dimen name="status_bar_connected_device_bt_indicator_size">15dp</dimen>
 
     <!-- Height of a small notification in the status bar-->
     <dimen name="notification_min_height">106dp</dimen>
@@ -700,13 +700,13 @@
     <dimen name="fake_shadow_size">8dp</dimen>
 
     <!-- Starting margin before the signal cluster -->
-    <dimen name="signal_cluster_margin_start">2.5dp</dimen>
+    <dimen name="signal_cluster_margin_start">2dp</dimen>
 
     <!-- Padding between signal cluster and battery icon -->
-    <dimen name="signal_cluster_battery_padding">6dp</dimen>
+    <dimen name="signal_cluster_battery_padding">4dp</dimen>
 
     <!-- Padding for signal cluster and battery icon when there are not icons in signal cluster -->
-    <dimen name="no_signal_cluster_battery_padding">3dp</dimen>
+    <dimen name="no_signal_cluster_battery_padding">4dp</dimen>
 
     <!-- Screen pinning request width -->
     <dimen name="screen_pinning_request_width">@dimen/match_parent</dimen>


### PR DESCRIPTION
With all these notched devices out there, status bar real estate
value is at an all-time-high. Lets minimine the gap between status
bar icons just enough to where the user won't notice, yet it allows
for one extra icon.

Signed-off-by: calebcabob <calphonic@gmail.com>

Change-Id: Ifb689b463e22d5f4759fd538b7cdf1d3153808e6