### PR TITLE
Whitelist font manager

### DIFF
--- a/data/etc/privapp-permissions-platform.xml
+++ b/data/etc/privapp-permissions-platform.xml
@@ -241,6 +241,7 @@ applications that come with the platform
 
     <privapp-permissions package="com.android.settings">
         <permission name="android.permission.ACCESS_CHECKIN_PROPERTIES"/>
+        <permission name="android.permission.ACCESS_FONT_MANAGER"/>
         <permission name="android.permission.ACCESS_NOTIFICATIONS"/>
         <permission name="android.permission.BACKUP"/>
         <permission name="android.permission.BATTERY_STATS"/>


### PR DESCRIPTION
Whitelist ACCESS_FONT_MANAGER in com.android.settings because it would cause bootloops in devices enforcing priv-app permissions whitelist.

Example of a bootlog crash -
07-11 06:26:13.167  1703  1703 E AndroidRuntime: *** FATAL EXCEPTION IN SYSTEM PROCESS: main
07-11 06:26:13.167  1703  1703 E AndroidRuntime: java.lang.IllegalStateException: Signature|privileged permissions not in privapp-permissions whitelist: {com.android.settings: android.permission.ACCESS_FONT_MANAGER}

The process is defined here -
https://github.com/crdroidandroid/android_frameworks_base/blob/231b61c24b4d223a0a30b309dca41403030aad54/services/core/java/com/android/server/FontService.java#L562