### PR TITLE
SystemUI: Fix disable QS pulldown on secure lockscreen

### DIFF
--- a/packages/SystemUI/plugin/src/com/android/systemui/plugins/qs/QS.java
+++ b/packages/SystemUI/plugin/src/com/android/systemui/plugins/qs/QS.java
@@ -57,6 +57,7 @@ public interface QS extends FragmentBase {
     void setQsExpansion(float qsExpansionFraction, float headerTranslation);
     void setHeaderListening(boolean listening);
     void notifyCustomizeChanged();
+    void setSecureExpandDisabled(boolean value);
 
     void setContainer(ViewGroup container);
     void setExpandClickListener(OnClickListener onClickListener);

--- a/packages/SystemUI/src/com/android/systemui/qs/QSFragment.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSFragment.java
@@ -106,6 +106,9 @@ public class QSFragment extends LifecycleFragment implements QS, CommandQueue.Ca
         mStatusBarStateController = statusBarStateController;
     }
 
+    // custom additions
+    private boolean mSecureExpandDisabled;
+
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
             Bundle savedInstanceState) {
@@ -361,7 +364,7 @@ public class QSFragment extends LifecycleFragment implements QS, CommandQueue.Ca
         boolean onKeyguardAndExpanded = isKeyguardShowing() && !mShowCollapsedOnKeyguard;
         if (!mHeaderAnimating && !headerWillBeAnimating()) {
             getView().setTranslationY(
-                    onKeyguardAndExpanded
+                    (onKeyguardAndExpanded || mSecureExpandDisabled)
                             ? translationScaleY * mHeader.getHeight()
                             : headerTranslation);
         }
@@ -408,6 +411,9 @@ public class QSFragment extends LifecycleFragment implements QS, CommandQueue.Ca
 
     @Override
     public void animateHeaderSlidingIn(long delay) {
+        if (mSecureExpandDisabled) {
+            return;
+        }
         if (DEBUG) Log.d(TAG, "animateHeaderSlidingIn");
         // If the QS is already expanded we don't need to slide in the header as it's already
         // visible.
@@ -490,7 +496,12 @@ public class QSFragment extends LifecycleFragment implements QS, CommandQueue.Ca
 
     @Override
     public int getQsMinExpansionHeight() {
-        return mHeader.getHeight();
+        return mSecureExpandDisabled ? 0 : mHeader.getHeight();
+    }
+
+    @Override
+    public void setSecureExpandDisabled(boolean value) {
+        mSecureExpandDisabled = value;
     }
 
     @Override

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
@@ -59,7 +59,6 @@ import android.widget.FrameLayout;
 import com.android.internal.annotations.VisibleForTesting;
 import com.android.internal.logging.MetricsLogger;
 import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
-import com.android.internal.widget.LockPatternUtils;
 import com.android.keyguard.KeyguardClockSwitch;
 import com.android.keyguard.KeyguardStatusView;
 import com.android.keyguard.KeyguardUpdateMonitor;
@@ -226,6 +225,11 @@ public class NotificationPanelView extends PanelView implements
                         mDelayShowingKeyguardStatusBar = false;
                     }
                 }
+
+                @Override
+                public void onKeyguardShowingChanged() {
+                    mStatusBar.updateQsExpansionEnabled();
+                }
             };
 
     private final InjectionInflationController mInjectionInflationController;
@@ -273,7 +277,6 @@ public class NotificationPanelView extends PanelView implements
     private boolean mQsExpandedWhenExpandingStarted;
     private boolean mQsFullyExpanded;
     private boolean mKeyguardShowing;
-    private boolean mKeyguardOrShadeShowing;
     private boolean mDozing;
     private boolean mDozingOnDown;
     protected int mBarState;
@@ -350,8 +353,6 @@ public class NotificationPanelView extends PanelView implements
     private boolean mPulseLights;
     private boolean mShowLockscreenStatusBar;
     private boolean mStatusBarShownOnSecureKeyguard;
-
-    private LockPatternUtils mLockPatternUtils;
 
     private Runnable mHeadsUpExistenceChangedRunnable = new Runnable() {
         @Override
@@ -513,7 +514,6 @@ public class NotificationPanelView extends PanelView implements
         });
         mBottomAreaShadeAlphaAnimator.setDuration(160);
         mBottomAreaShadeAlphaAnimator.setInterpolator(Interpolators.ALPHA_OUT);
-        mLockPatternUtils = new LockPatternUtils(mContext);
         mDoubleTapGesture = new GestureDetector(mContext,
                 new GestureDetector.SimpleOnGestureListener() {
             @Override
@@ -637,6 +637,7 @@ public class NotificationPanelView extends PanelView implements
             case LOCKSCREEN_ENABLE_QS:
                 mStatusBarShownOnSecureKeyguard =
                         TunerService.parseIntegerSwitch(newValue, true);
+                mStatusBar.updateQsExpansionEnabled();
             default:
                 break;
         }
@@ -1018,10 +1019,10 @@ public class NotificationPanelView extends PanelView implements
     }
 
     private boolean isQSEventBlocked() {
-        if (!mKeyguardOrShadeShowing)
+        if (!mKeyguardMonitor.isShowing())
             return false;
 
-        if (!mLockPatternUtils.isSecure(KeyguardUpdateMonitor.getCurrentUser()))
+        if (!mKeyguardMonitor.isSecure())
             return false;
 
         return !mStatusBarShownOnSecureKeyguard;
@@ -1031,6 +1032,7 @@ public class NotificationPanelView extends PanelView implements
         mQsExpansionEnabled = qsExpansionEnabled;
         if (mQs == null) return;
         mQs.setHeaderClickable(mQsExpansionEnabled);
+        mQs.setSecureExpandDisabled(!mQsExpansionEnabled);
     }
 
     @Override
@@ -1476,7 +1478,8 @@ public class NotificationPanelView extends PanelView implements
         }
         showQsOverride &= mBarState == StatusBarState.SHADE;
 
-        return twoFingerDrag || showQsOverride || stylusButtonClickDrag || mouseButtonClickDrag;
+        return !isQSEventBlocked() && (twoFingerDrag || showQsOverride
+                || stylusButtonClickDrag || mouseButtonClickDrag);
     }
 
     private void handleQsDown(MotionEvent event) {
@@ -1647,8 +1650,8 @@ public class NotificationPanelView extends PanelView implements
         mLastOverscroll = 0f;
         mQsExpansionFromOverscroll = false;
         setQsExpansion(mQsExpansionHeight);
-        flingSettings(!mQsExpansionEnabled && open ? 0f : velocity,
-                open && mQsExpansionEnabled ? FLING_EXPAND : FLING_COLLAPSE,
+        flingSettings((!mQsExpansionEnabled || isQSEventBlocked()) && open ? 0f : velocity,
+                open && (mQsExpansionEnabled && !isQSEventBlocked()) ? FLING_EXPAND : FLING_COLLAPSE,
                 new Runnable() {
                     @Override
                     public void run() {
@@ -1713,7 +1716,9 @@ public class NotificationPanelView extends PanelView implements
 
         mBarState = statusBarState;
         mKeyguardShowing = keyguardShowing;
-        mKeyguardOrShadeShowing = keyguardOrShadeShowing;
+        if (mQs != null) {
+            mQs.setSecureExpandDisabled(isQSEventBlocked());
+        }
 
         if (oldState == StatusBarState.KEYGUARD
                 && (goingToFullShade || statusBarState == StatusBarState.SHADE_LOCKED)) {
@@ -2164,8 +2169,8 @@ public class NotificationPanelView extends PanelView implements
      * @return Whether we should intercept a gesture to open Quick Settings.
      */
     private boolean shouldQuickSettingsIntercept(float x, float y, float yDiff) {
-        if (!mQsExpansionEnabled || mCollapsedOnDown
-                || (mKeyguardShowing && mKeyguardBypassController.getBypassEnabled()) || isQSEventBlocked()) {
+        if (!mQsExpansionEnabled || mCollapsedOnDown || isQSEventBlocked()
+                || (mKeyguardShowing && mKeyguardBypassController.getBypassEnabled())) {
             return false;
         }
         View header = mKeyguardShowing || mQs == null ? mKeyguardStatusBar : mQs.getHeader();
@@ -3349,6 +3354,7 @@ public class NotificationPanelView extends PanelView implements
             mQs.setHeaderClickable(mQsExpansionEnabled);
             updateQSPulseExpansion();
             mQs.setOverscrolling(mStackScrollerOverscrolling);
+            mQs.setSecureExpandDisabled(isQSEventBlocked());
 
             // recompute internal state when qspanel height changes
             mQs.getView().addOnLayoutChangeListener(

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
@@ -1568,7 +1568,7 @@ public class StatusBar extends SystemUI implements DemoMode,
      * If the user switcher is simple then disable QS during setup because
      * the user intends to use the lock screen user switcher, QS in not needed.
      */
-    private void updateQsExpansionEnabled() {
+    public void updateQsExpansionEnabled() {
         final boolean expandEnabled = mDeviceProvisionedController.isDeviceProvisioned()
                 && (mUserSetup || mUserSwitcherController == null
                         || !mUserSwitcherController.isSimpleUserSwitcher())


### PR DESCRIPTION
Based on commits:

Commit 1

From e5d6c1e3683c1a87b10e7da9323f32c5d0fa3a7e Mon Sep 17 00:00:00 2001
From: Marko Man <darkobas@gmail.com>
Date: Sat, 5 Oct 2019 22:44:48 +0200
Subject: [PATCH] base: allow disabling quick settings on secure lock screens

inspired by
SlimRoms/frameworks_base@b76f8af
DirtyUnicorns/android_frameworks_base@3a4d3be

xyyx: adapted to Oreo

Change-Id: I90736961fd8023b06b544e9a96a43be4202707e4
Signed-off-by: enzoo96 <enzoo.site@gmail.com>

Commit 2

From 1bb7a657b58f3490e5cb02a20525a3a29107bb97 Mon Sep 17 00:00:00 2001
From: maxwen <max.weninger@gmail.com>
Date: Tue, 8 Oct 2019 16:18:45 +0200
Subject: [PATCH] base: fix disabling quick settings on secure lock screens

Change-Id: I50a75c3ddd32423dda1e71ba1d508d8ad6de4bc6

Commit 3

From 143c478174ce407522cf07f772cc86478a0bb39f Mon Sep 17 00:00:00 2001
From: Marko Man <darkobas@gmail.com>
Date: Wed, 9 Oct 2019 10:06:25 +0200
Subject: [PATCH] SystemUI: Fix disable QS pulldown on secure lockscreens

Change-Id: Ide95a72ff7b271476a8b3f8fbf163db8b7187b01

Commit 4

From 3c6f934d0ad57477e95501c0aae9b78d039da1c4 Mon Sep 17 00:00:00 2001
From: maxwen <max.weninger@gmail.com>
Date: Sat, 9 Nov 2019 23:53:10 +0100
Subject: [PATCH] SystemUI: block open doors for disabled secure lock qs expand

Change-Id: I4a4084e5fe8fb2a0989a367f2b4234a9ef60b7f7

Commit 5

From 6dbfaaec7b9a48dd8eda97d4a95f14b3bfc6b32f Mon Sep 17 00:00:00 2001
From: Pranav Vashi <neobuddy89@gmail.com>
Date: Sun, 31 Mar 2019 21:05:30 +0530
Subject: [PATCH] Fix issues with QS access on secured lockscreen

* This should fix issue where QS was still accessible via emergency screen.

Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>