### PR TITLE
Unlock with fingerprint on notification double tap without pin/passwa…

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -9936,6 +9936,12 @@ public final class Settings {
         public static final String SHOW_BACK_ARROW_GESTURE = "show_back_arrow_gesture";
 
         /**
+         * Whether to unlock with fingerprint on notification double tap
+         * @hide
+         */
+        public static final String UNLOCK_WITHOUT_BOUNCER = "unlock_without_bouncer";
+
+        /**
          * This are the settings to be backed up.
          *
          * NOTE: Settings are backed up and restored in the order they appear

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardBouncer.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardBouncer.java
@@ -24,6 +24,7 @@ import android.content.res.ColorStateList;
 import android.os.Handler;
 import android.os.UserHandle;
 import android.os.UserManager;
+import android.provider.Settings;
 import android.util.Log;
 import android.util.MathUtils;
 import android.util.Slog;
@@ -96,6 +97,7 @@ public class KeyguardBouncer {
     private boolean mIsAnimatingAway;
     private boolean mIsScrimmed;
     private ViewGroup mLockIconContainer;
+    private boolean mUnlockWithoutBouncer = false;
 
     public static final int UNLOCK_SEQUENCE_DEFAULT = 0;
     public static final int UNLOCK_SEQUENCE_BOUNCER_FIRST = 1;
@@ -175,6 +177,11 @@ public class KeyguardBouncer {
         // This condition may indicate an error on Android, so log it.
         if (!allowDismissKeyguard) {
             Slog.w(TAG, "User can't dismiss keyguard: " + activeUserId + " != " + keyguardUserId);
+        }
+
+        if (mUnlockWithoutBouncer) {
+            mUnlockWithoutBouncer = false;
+            return;
         }
 
         mShowingSoon = true;
@@ -294,6 +301,9 @@ public class KeyguardBouncer {
     public void showWithDismissAction(OnDismissAction r, Runnable cancelAction) {
         ensureView();
         mKeyguardView.setOnDismissAction(r, cancelAction);
+        mUnlockWithoutBouncer = Settings.Secure.getInt(mContext.getContentResolver(),
+                Settings.Secure.UNLOCK_WITHOUT_BOUNCER, 0) != 0
+                && mKeyguardUpdateMonitor.isUnlockingWithBiometricAllowed();
         show(false /* resetSecuritySelection */);
     }
 


### PR DESCRIPTION
…rd/pattern [1/2]

When double tapping on notification on secure lockscreen bouncer is shown by default.
This patch adding ability to unlock with fingerprint.