### PR TITLE
Revert "Unlock without bouncer: Use Tuner API"

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardBouncer.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardBouncer.java
@@ -24,6 +24,7 @@ import android.content.res.ColorStateList;
 import android.os.Handler;
 import android.os.UserHandle;
 import android.os.UserManager;
+import android.provider.Settings;
 import android.util.Log;
 import android.util.MathUtils;
 import android.util.Slog;
@@ -96,7 +97,7 @@ public class KeyguardBouncer {
     private boolean mIsAnimatingAway;
     private boolean mIsScrimmed;
     private ViewGroup mLockIconContainer;
-    private boolean mUnlockWithoutBouncer;
+    private boolean mUnlockWithoutBouncer = false;
 
     public static final int UNLOCK_SEQUENCE_DEFAULT = 0;
     public static final int UNLOCK_SEQUENCE_BOUNCER_FIRST = 1;
@@ -178,7 +179,8 @@ public class KeyguardBouncer {
             Slog.w(TAG, "User can't dismiss keyguard: " + activeUserId + " != " + keyguardUserId);
         }
 
-        if (mUnlockWithoutBouncer && mKeyguardUpdateMonitor.isUnlockingWithBiometricAllowed()) {
+        if (mUnlockWithoutBouncer) {
+            mUnlockWithoutBouncer = false;
             return;
         }
 
@@ -296,13 +298,12 @@ public class KeyguardBouncer {
         mShowingSoon = false;
     }
 
-    public void setUnlockWithoutBouncer(boolean unlockWithoutBouncer) {
-        mUnlockWithoutBouncer = unlockWithoutBouncer;
-    }
-
     public void showWithDismissAction(OnDismissAction r, Runnable cancelAction) {
         ensureView();
         mKeyguardView.setOnDismissAction(r, cancelAction);
+        mUnlockWithoutBouncer = Settings.Secure.getInt(mContext.getContentResolver(),
+                Settings.Secure.UNLOCK_WITHOUT_BOUNCER, 0) != 0
+                && mKeyguardUpdateMonitor.isUnlockingWithBiometricAllowed();
         show(false /* resetSecuritySelection */);
     }
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarKeyguardViewManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarKeyguardViewManager.java
@@ -94,11 +94,8 @@ public class StatusBarKeyguardViewManager implements RemoteInputController.Callb
 
     private static final String LOCKSCREEN_LOCK_ICON =
             "system:" + Settings.System.LOCKSCREEN_LOCK_ICON;
-    private static final String UNLOCK_WITHOUT_BOUNCER =
-            Settings.Secure.UNLOCK_WITHOUT_BOUNCER;
 
     private boolean mLockIcon;
-    private boolean mUnlockWithoutBouncer;
 
     protected final Context mContext;
     private final StatusBarWindowController mStatusBarWindowController;
@@ -219,7 +216,6 @@ public class StatusBarKeyguardViewManager implements RemoteInputController.Callb
             mIsDocked = mDockManager.isDocked();
         }
         Dependency.get(TunerService.class).addTunable(this, LOCKSCREEN_LOCK_ICON);
-        Dependency.get(TunerService.class).addTunable(this, UNLOCK_WITHOUT_BOUNCER);
     }
 
     public void registerStatusBar(StatusBar statusBar,
@@ -239,7 +235,6 @@ public class StatusBarKeyguardViewManager implements RemoteInputController.Callb
         mBouncer = SystemUIFactory.getInstance().createKeyguardBouncer(mContext,
                 mViewMediatorCallback, mLockPatternUtils, container, dismissCallbackRegistry,
                 mExpansionCallback, falsingManager, bypassController);
-        mBouncer.setUnlockWithoutBouncer(mUnlockWithoutBouncer);
         mNotificationPanelView = notificationPanelView;
         notificationPanelView.addExpansionListener(this);
         mBypassController = bypassController;
@@ -252,11 +247,6 @@ public class StatusBarKeyguardViewManager implements RemoteInputController.Callb
             case LOCKSCREEN_LOCK_ICON:
                 mLockIcon =
                     TunerService.parseIntegerSwitch(newValue, true);
-                break;
-            case UNLOCK_WITHOUT_BOUNCER:
-                mUnlockWithoutBouncer =
-                    TunerService.parseIntegerSwitch(newValue, false);
-                if (mBouncer != null) mBouncer.setUnlockWithoutBouncer(mUnlockWithoutBouncer);
                 break;
             default:
                 break;


### PR DESCRIPTION
This reverts commit 28d0816e94b6ba7ea49154d52a7d9fb700317216.

This change introduced issue when bouncer can't be accesed by swipe.