### PR TITLE
Wired/BT headset: make ringtone audio focus customizable [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -14946,6 +14946,12 @@ public final class Settings {
         public static final String REFRESH_RATE_SETTING = "refresh_rate_setting";
 
         /**
+         * Audio focus mode for ringtones when headset is connected
+         * @hide
+         */
+        public static final String RINGTONE_FOCUS_MODE = "ringtone_focus_mode";
+
+        /**
          * Settings to backup. This is here so that it's in the same place as the settings
          * keys and easy to update.
          *


### PR DESCRIPTION
Allow to choose where to play incoming call ringtones from
if a wired or BT headset is plugged in.
Mode 0: play the ringtone from the headset but only if music is playing (if no
music, play from speakerphone)
Mode 1 (default aosp behavior): always play the ringtone from both speakerphone
and headset

thanks @xyyx for unlinking the code form the Telecomm tree

Change-Id: I065df661c1068ce11d8906539077c442b9152f29