### PR TITLE
SettingLib: Add deep sleep info to uptime preference

### DIFF
--- a/packages/SettingsLib/res/values/strings.xml
+++ b/packages/SettingsLib/res/values/strings.xml
@@ -1180,4 +1180,7 @@
 
     <!-- Name of the this device. [CHAR LIMIT=30] -->
     <string name="media_transfer_this_device_name">This device</string>
+
+    <!-- Deep sleep info -->
+    <string name="status_deep_sleep">(Deep sleep: %1$d%2$s)</string>
 </resources>

--- a/packages/SettingsLib/src/com/android/settingslib/deviceinfo/AbstractUptimePreferenceController.java
+++ b/packages/SettingsLib/src/com/android/settingslib/deviceinfo/AbstractUptimePreferenceController.java
@@ -26,6 +26,7 @@ import androidx.annotation.VisibleForTesting;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceScreen;
 
+import com.android.settingslib.R;
 import com.android.settingslib.core.AbstractPreferenceController;
 import com.android.settingslib.core.lifecycle.Lifecycle;
 import com.android.settingslib.core.lifecycle.LifecycleObserver;
@@ -89,7 +90,18 @@ public abstract class AbstractUptimePreferenceController extends AbstractPrefere
     }
 
     private void updateTimes() {
-        mUptime.setSummary(DateUtils.formatElapsedTime(SystemClock.elapsedRealtime() / 1000));
+        long ut = Math.max((SystemClock.elapsedRealtime() / 1000), 1);
+
+        float deepSleepRatio = Math.max((float) (SystemClock.elapsedRealtime() - SystemClock.uptimeMillis()), 0f)
+                / SystemClock.elapsedRealtime();
+        int deepSleepPercent = Math.round(deepSleepRatio * 100);
+
+        final StringBuilder summary = new StringBuilder();
+        summary.append(DateUtils.formatElapsedTime(SystemClock.elapsedRealtime() / 1000));
+        summary.append(" ");
+        summary.append(mContext.getString(R.string.status_deep_sleep, deepSleepPercent, "%"));
+
+        mUptime.setSummary(summary.toString());
     }
 
     private static class MyHandler extends Handler {


### PR DESCRIPTION
Add deep sleep ratio to "About Phone" -> "Uptime"
original from Stefan