### PR TITLE
NetworkTraffic: Simplify and Cleanup (Revised)

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/NetworkTraffic.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/NetworkTraffic.java
@@ -69,6 +69,10 @@ public class NetworkTraffic extends TextView {
     private static final int MODE_UPSTREAM_ONLY = 1;
     private static final int MODE_DOWNSTREAM_ONLY = 2;
 
+    private static final int LOCATION_DISABLED = 0;
+    private static final int LOCATION_STATUSBAR = 1;
+    private static final int LOCATION_QUICK_STATUSBAR = 2;
+
     private static final int MESSAGE_TYPE_PERIODIC_REFRESH = 0;
     private static final int MESSAGE_TYPE_UPDATE_VIEW = 1;
 
@@ -76,13 +80,10 @@ public class NetworkTraffic extends TextView {
     private static final int Mega = Kilo * Kilo;
     private static final int Giga = Mega * Kilo;
 
-    protected int mLocation = 0;
+    protected int mLocation = LOCATION_DISABLED;
     private int mMode = MODE_UPSTREAM_AND_DOWNSTREAM;
     private int mSubMode = MODE_UPSTREAM_AND_DOWNSTREAM;
-    private boolean mConnectionAvailable;
     protected boolean mIsActive;
-    private long mTxBytes;
-    private long mRxBytes;
     private long mLastTxBytes;
     private long mLastRxBytes;
     private long mLastUpdateTime;
@@ -155,80 +156,61 @@ public class NetworkTraffic extends TextView {
         @Override
         public void handleMessage(Message msg) {
             final long now = SystemClock.elapsedRealtime();
-            final long timeDelta = now - mLastUpdateTime; /* ms */
+            long timeDelta = now - mLastUpdateTime; /* ms */
+            long rxBytes = 0;
+            long txBytes = 0;
 
             if (msg.what == MESSAGE_TYPE_PERIODIC_REFRESH
                     && timeDelta >= mRefreshInterval * 1000 * 0.95f) {
-                // Sum tx and rx bytes from all sources of interest
-                long txBytes = 0;
-                long rxBytes = 0;
+                long[] newTotalRxTxBytes = getTotalRxTxBytes();
 
-                // Add stats
-                final long newTxBytes = TrafficStats.getTotalTxBytes();
-                final long newRxBytes = TrafficStats.getTotalRxBytes();
-
-                txBytes += newTxBytes;
-                rxBytes += newRxBytes;
-
-                // Add tether hw offload counters since these are
-                // not included in netd interface stats.
-                final TetheringStats tetheringStats = getOffloadTetheringStats();
-                txBytes += tetheringStats.txBytes;
-                rxBytes += tetheringStats.rxBytes;
-
-                if (DEBUG) {
-                    Log.d(TAG, "tether hw offload txBytes: " + tetheringStats.txBytes
-                            + " rxBytes: " + tetheringStats.rxBytes);
+                if (timeDelta < 1) {
+                    timeDelta = Long.MAX_VALUE;
                 }
 
-                final long txBytesDelta = txBytes - mLastTxBytes;
-                final long rxBytesDelta = rxBytes - mLastRxBytes;
+                final long rxBytesDelta = newTotalRxTxBytes[0] - mLastRxBytes;
+                final long txBytesDelta = newTotalRxTxBytes[1] - mLastTxBytes;
 
-                if (timeDelta > 0 && txBytesDelta >= 0 && rxBytesDelta >= 0) {
-                    mTxBytes = (long) (txBytesDelta / (timeDelta / 1000f));
-                    mRxBytes = (long) (rxBytesDelta / (timeDelta / 1000f));
-                }
-                mLastTxBytes = txBytes;
-                mLastRxBytes = rxBytes;
+                rxBytes = (long) (rxBytesDelta / (timeDelta / 1000f));
+                txBytes = (long) (txBytesDelta / (timeDelta / 1000f));
+
+                mLastRxBytes = newTotalRxTxBytes[0];
+                mLastTxBytes = newTotalRxTxBytes[1];
                 mLastUpdateTime = now;
             }
 
-            mConnectionAvailable = isConnectionAvailable();
-            final boolean enabled = mLocation != 0 && mScreenOn;
-            final boolean showUpstream =
-                    mMode == MODE_UPSTREAM_ONLY || mMode == MODE_UPSTREAM_AND_DOWNSTREAM;
-            final boolean showDownstream =
-                    mMode == MODE_DOWNSTREAM_ONLY || mMode == MODE_UPSTREAM_AND_DOWNSTREAM;
-            final boolean aboveThreshold = (showUpstream && mTxBytes > mAutoHideThreshold)
-                    || (showDownstream && mRxBytes > mAutoHideThreshold);
-            mIsActive = enabled && mAttached && (!mAutoHide || (mConnectionAvailable && aboveThreshold));
-            int submode = MODE_UPSTREAM_AND_DOWNSTREAM;
+            final boolean enabled = mLocation != LOCATION_DISABLED && mScreenOn;
+            final boolean aboveThreshold = isAboveThreshold(rxBytes, txBytes);
+            int submode = MODE_DOWNSTREAM_ONLY;
+
+            mIsActive = enabled && mAttached && (!mAutoHide || aboveThreshold);
 
             clearHandlerCallbacks();
 
             if (mIsActive) {
                 CharSequence output = "";
-                if (showUpstream && showDownstream) {
-                    if (mTxBytes > mRxBytes) {
-                        output = formatOutput(mTxBytes);
+
+                if (mMode != MODE_DOWNSTREAM_ONLY) {
+                    if (txBytes > rxBytes || mMode == MODE_UPSTREAM_ONLY) {
+                        output = formatOutput(txBytes);
                         submode = MODE_UPSTREAM_ONLY;
-                    } else if (mTxBytes < mRxBytes) {
-                        output = formatOutput(mRxBytes);
-                        submode = MODE_DOWNSTREAM_ONLY;
                     } else {
-                        output = formatOutput(mRxBytes);
-                        submode = MODE_UPSTREAM_AND_DOWNSTREAM;
+                        output = formatOutput(rxBytes);
+
+                        if (txBytes == rxBytes) {
+                            submode = mMode;
+                        }
                     }
-                } else if (showDownstream) {
-                    output = formatOutput(mRxBytes);
-                } else if (showUpstream) {
-                    output = formatOutput(mTxBytes);
+                } else {
+                    output = formatOutput(rxBytes);
                 }
 
                 // Update view if there's anything new to show
                 if (output != getText()) {
                     setText(output);
                 }
+            } else {
+                setText("");
             }
 
             updateVisibility();
@@ -270,7 +252,7 @@ public class NetworkTraffic extends TextView {
                 decimalFormat = new DecimalFormat("0.00");
                 formatSpeed =  decimalFormat.format(speed / (float)Giga);
             } else if (speed >= 100 * Mega) {
-                decimalFormat = new DecimalFormat("###0");
+                decimalFormat = new DecimalFormat("##0");
                 unit = munit;
                 formatSpeed =  decimalFormat.format(speed / (float)Mega);
             } else if (speed >= 10 * Mega) {
@@ -290,7 +272,7 @@ public class NetworkTraffic extends TextView {
                 unit = kunit;
                 formatSpeed =  decimalFormat.format(speed / (float)Kilo);
             } else {
-                decimalFormat = new DecimalFormat("0.00");
+                decimalFormat = new DecimalFormat("0.##");
                 unit = kunit;
                 formatSpeed = decimalFormat.format(speed / (float)Kilo);
             }
@@ -303,10 +285,45 @@ public class NetworkTraffic extends TextView {
                     Spanned.SPAN_INCLUSIVE_INCLUSIVE);
             return TextUtils.concat(spanSpeedString, "\n", spanUnitString);
         }
+
+        private boolean isAboveThreshold(long rxBytes, long txBytes) {
+            final long rxKB = (long)rxBytes / Kilo;
+            final long txKB = (long)txBytes / Kilo;
+            final boolean showUpstream =
+                    mMode == MODE_UPSTREAM_ONLY || mMode == MODE_UPSTREAM_AND_DOWNSTREAM;
+            final boolean showDownstream =
+                    mMode == MODE_DOWNSTREAM_ONLY || mMode == MODE_UPSTREAM_AND_DOWNSTREAM;
+
+            return isConnectionAvailable() &&
+                   (showDownstream && rxKB > mAutoHideThreshold) ||
+                   (showUpstream && txKB > mAutoHideThreshold);
+        }
+
+        private long[] getTotalRxTxBytes() {
+            long[] bytes = new long[] { 0, 0 };
+
+            // Sum tx and rx bytes from all sources of interest
+            // Add stats
+            bytes[0] = TrafficStats.getTotalRxBytes();
+            bytes[1] = TrafficStats.getTotalTxBytes();
+
+            // Add tether hw offload counters since these are
+            // not included in netd interface stats.
+            final TetheringStats tetheringStats = getOffloadTetheringStats();
+            bytes[0] += tetheringStats.rxBytes;
+            bytes[1] += tetheringStats.txBytes;
+
+            if (DEBUG) {
+                Log.d(TAG, "tether hw offload txBytes: " + tetheringStats.txBytes
+                        + " rxBytes: " + tetheringStats.rxBytes);
+            }
+
+            return bytes;
+        }
     };
 
     protected void updateVisibility() {
-        boolean enabled = mIsActive && (mLocation == 2) && mScreenOn && getText() != "";
+        boolean enabled = mIsActive && (mLocation == LOCATION_QUICK_STATUSBAR) && mScreenOn && getText() != "";
         if (enabled != mVisible) {
             mVisible = enabled;
             setVisibility(mVisible ? VISIBLE : GONE);
@@ -455,7 +472,7 @@ public class NetworkTraffic extends TextView {
     }
 
     protected void updateViews() {
-        if (mLocation == 2 && mScreenOn) {
+        if (mLocation == LOCATION_QUICK_STATUSBAR && mScreenOn) {
             updateViewState();
         } else {
             clearHandlerCallbacks();
@@ -474,24 +491,18 @@ public class NetworkTraffic extends TextView {
     }
 
     protected void setTrafficDrawable() {
-        final int drawableResId;
+        int drawableResId = 0;
         final Resources resources = getResources();
         final Drawable drawable;
 
-        if (!mHideArrows && mMode == MODE_UPSTREAM_AND_DOWNSTREAM) {
-            if (mSubMode == MODE_DOWNSTREAM_ONLY) {
-                drawableResId = R.drawable.stat_sys_network_traffic_down;
-            } else if (mSubMode == MODE_UPSTREAM_ONLY) {
+        if (!mHideArrows) {
+            if (mSubMode == MODE_UPSTREAM_ONLY) {
                 drawableResId = R.drawable.stat_sys_network_traffic_up;
+            } else if (mSubMode == MODE_DOWNSTREAM_ONLY) {
+                drawableResId = R.drawable.stat_sys_network_traffic_down;
             } else {
                 drawableResId = R.drawable.stat_sys_network_traffic_updown;
             }
-        } else if (!mHideArrows && mMode == MODE_UPSTREAM_ONLY) {
-            drawableResId = R.drawable.stat_sys_network_traffic_up;
-        } else if (!mHideArrows && mMode == MODE_DOWNSTREAM_ONLY) {
-            drawableResId = R.drawable.stat_sys_network_traffic_down;
-        } else {
-            drawableResId = 0;
         }
         drawable = drawableResId != 0 ? resources.getDrawable(drawableResId) : null;
         if (mDrawable != drawable || mIconTint != newTint) {


### PR DESCRIPTION
* Improve code readability.

* Put getting total Rx/Tx data in a function.

* Wrap checking for aboveThreshold in a function,
  also convert speed to Kilo/Speed before check.

* Simplify handleMessage() & setTrafficDrawable().
  Since we are not showing 2 way traffic together
  anymore, there is no point for this if/else checks.

* Remove an extra # from 100 * Mega check, we will
  show speed in Giga if speed is >999 Mega anyway.

* Modify "0.00" pattern to "0.##" for Kilo speed scale.
  This will show "0 KB/s" instead of "0.00 KB/s".

  Decimal separator does not show if there is no
  fraction in formated number.

Signed-off-by: Gobinda Joy <gobinda.joy@gmail.com>