### PR TITLE
NetworkTraffic: Improvements and cleanup

### DIFF
--- a/packages/SystemUI/res/drawable/stat_sys_network_traffic.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_network_traffic.xml
@@ -31,7 +31,7 @@
 
     <path
         android:name="up"
-        android:fillColor="#FFFFFFFF"
+        android:fillColor="#4DFFFFFF"
         android:pathData="M3.6000004,10.8l3.5,0.0 -3.5,-7.3 0.0,0.0 0.0,0.0 0.0,0.0 0.0,0.0 -3.6,7.3z"/>
 </vector>
 </inset>

--- a/packages/SystemUI/res/drawable/stat_sys_network_traffic_down.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_network_traffic_down.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
      Copyright (C) 2019-2020 crDroid Android Project
 
@@ -14,20 +13,25 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="14dp"
-    android:height="18dp"
-    android:viewportWidth="14"
-    android:viewportHeight="18">
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:insetLeft="2dp"
+    android:insetRight="2dp"
+    android:insetTop="6dp"
+    android:insetBottom="6dp">
+<vector
+    android:width="5dp"
+    android:height="17.0dp"
+    android:viewportWidth="7.1"
+    android:viewportHeight="24.0">
 
     <path
         android:name="down"
         android:fillColor="#FFFFFFFF"
-        android:pathData="M9,16l3-3h-2V8H8v5H6L9,16z" />
+        android:pathData="M3.6000004,13.2l-3.6,0.0 3.6,7.3 0.0,0.0 0.0,0.0 0.0,0.0 0.0,0.0 3.5,-7.3z"/>
 
     <path
         android:name="up"
         android:fillColor="#4DFFFFFF"
-        android:pathData="M5,2L2,5h2v5h2V5h2L5,2z" />
-
+        android:pathData="M3.6000004,10.8l3.5,0.0 -3.5,-7.3 0.0,0.0 0.0,0.0 0.0,0.0 0.0,0.0 -3.6,7.3z"/>
 </vector>
+</inset>

--- a/packages/SystemUI/res/drawable/stat_sys_network_traffic_updown.xml
+++ b/packages/SystemUI/res/drawable/stat_sys_network_traffic_updown.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
      Copyright (C) 2019-2020 crDroid Android Project
 
@@ -14,20 +13,25 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="14dp"
-    android:height="18dp"
-    android:viewportWidth="14"
-    android:viewportHeight="18">
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:insetLeft="2dp"
+    android:insetRight="2dp"
+    android:insetTop="6dp"
+    android:insetBottom="6dp">
+<vector
+    android:width="5dp"
+    android:height="17.0dp"
+    android:viewportWidth="7.1"
+    android:viewportHeight="24.0">
 
     <path
         android:name="down"
         android:fillColor="#FFFFFFFF"
-        android:pathData="M9,16l3-3h-2V8H8v5H6L9,16z" />
+        android:pathData="M3.6000004,13.2l-3.6,0.0 3.6,7.3 0.0,0.0 0.0,0.0 0.0,0.0 0.0,0.0 3.5,-7.3z"/>
 
     <path
         android:name="up"
         android:fillColor="#FFFFFFFF"
-        android:pathData="M5,2L2,5h2v5h2V5h2L5,2z" />
-
+        android:pathData="M3.6000004,10.8l3.5,0.0 -3.5,-7.3 0.0,0.0 0.0,0.0 0.0,0.0 0.0,0.0 -3.6,7.3z"/>
 </vector>
+</inset>

--- a/packages/SystemUI/res/values/cr_strings.xml
+++ b/packages/SystemUI/res/values/cr_strings.xml
@@ -243,10 +243,10 @@
     <string name="status_bar_roaming">Roaming</string>
 
     <!-- Status bar network traffic monitor strings -->
-    <string name="kilobitspersecond_short">kb/s</string>
+    <string name="kilobitspersecond_short">Kb/s</string>
     <string name="megabitspersecond_short">Mb/s</string>
     <string name="gigabitspersecond_short">Gb/s</string>
-    <string name="kilobytespersecond_short">kB/s</string>
+    <string name="kilobytespersecond_short">KB/s</string>
     <string name="megabytespersecond_short">MB/s</string>
     <string name="gigabytespersecond_short">GB/s</string>
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/NetworkTraffic.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/NetworkTraffic.java
@@ -69,6 +69,10 @@ public class NetworkTraffic extends TextView {
     private static final int MODE_UPSTREAM_ONLY = 1;
     private static final int MODE_DOWNSTREAM_ONLY = 2;
 
+    private static final int LOCATION_DISABLED = 0;
+    private static final int LOCATION_STATUSBAR = 1;
+    private static final int LOCATION_QUICK_STATUSBAR = 2;
+
     private static final int MESSAGE_TYPE_PERIODIC_REFRESH = 0;
     private static final int MESSAGE_TYPE_UPDATE_VIEW = 1;
 
@@ -76,13 +80,11 @@ public class NetworkTraffic extends TextView {
     private static final int Mega = Kilo * Kilo;
     private static final int Giga = Mega * Kilo;
 
-    protected int mLocation = 0;
+    protected int mLocation = LOCATION_DISABLED;
     private int mMode = MODE_UPSTREAM_AND_DOWNSTREAM;
     private int mSubMode = MODE_UPSTREAM_AND_DOWNSTREAM;
-    private boolean mConnectionAvailable;
     protected boolean mIsActive;
-    private long mTxBytes;
-    private long mRxBytes;
+    private boolean mTrafficActive = false;
     private long mLastTxBytes;
     private long mLastRxBytes;
     private long mLastUpdateTime;
@@ -155,86 +157,67 @@ public class NetworkTraffic extends TextView {
         @Override
         public void handleMessage(Message msg) {
             final long now = SystemClock.elapsedRealtime();
-            final long timeDelta = now - mLastUpdateTime; /* ms */
+            long timeDelta = now - mLastUpdateTime; /* ms */
+            long rxBytes = 0;
+            long txBytes = 0;
 
             if (msg.what == MESSAGE_TYPE_PERIODIC_REFRESH
                     && timeDelta >= mRefreshInterval * 1000 * 0.95f) {
-                // Sum tx and rx bytes from all sources of interest
-                long txBytes = 0;
-                long rxBytes = 0;
+                long[] newTotalRxTxBytes = getTotalRxTxBytes();
 
-                // Add stats
-                final long newTxBytes = TrafficStats.getTotalTxBytes();
-                final long newRxBytes = TrafficStats.getTotalRxBytes();
-
-                txBytes += newTxBytes;
-                rxBytes += newRxBytes;
-
-                // Add tether hw offload counters since these are
-                // not included in netd interface stats.
-                final TetheringStats tetheringStats = getOffloadTetheringStats();
-                txBytes += tetheringStats.txBytes;
-                rxBytes += tetheringStats.rxBytes;
-
-                if (DEBUG) {
-                    Log.d(TAG, "tether hw offload txBytes: " + tetheringStats.txBytes
-                            + " rxBytes: " + tetheringStats.rxBytes);
+                if (timeDelta < 1) {
+                    timeDelta = Long.MAX_VALUE;
                 }
 
-                final long txBytesDelta = txBytes - mLastTxBytes;
-                final long rxBytesDelta = rxBytes - mLastRxBytes;
+                final long rxBytesDelta = newTotalRxTxBytes[0] - mLastRxBytes;
+                final long txBytesDelta = newTotalRxTxBytes[1] - mLastTxBytes;
 
-                if (timeDelta > 0 && txBytesDelta >= 0 && rxBytesDelta >= 0) {
-                    mTxBytes = (long) (txBytesDelta / (timeDelta / 1000f));
-                    mRxBytes = (long) (rxBytesDelta / (timeDelta / 1000f));
-                }
-                mLastTxBytes = txBytes;
-                mLastRxBytes = rxBytes;
+                rxBytes = (long) (rxBytesDelta / (timeDelta / 1000f));
+                txBytes = (long) (txBytesDelta / (timeDelta / 1000f));
+
+                mLastRxBytes = newTotalRxTxBytes[0];
+                mLastTxBytes = newTotalRxTxBytes[1];
                 mLastUpdateTime = now;
             }
 
-            mConnectionAvailable = isConnectionAvailable();
-            final boolean enabled = mLocation != 0 && mScreenOn;
-            final boolean showUpstream =
-                    mMode == MODE_UPSTREAM_ONLY || mMode == MODE_UPSTREAM_AND_DOWNSTREAM;
-            final boolean showDownstream =
-                    mMode == MODE_DOWNSTREAM_ONLY || mMode == MODE_UPSTREAM_AND_DOWNSTREAM;
-            final boolean aboveThreshold = (showUpstream && mTxBytes > mAutoHideThreshold)
-                    || (showDownstream && mRxBytes > mAutoHideThreshold);
-            mIsActive = enabled && mAttached && (!mAutoHide || (mConnectionAvailable && aboveThreshold));
-            int submode = MODE_UPSTREAM_AND_DOWNSTREAM;
+            final boolean enabled = mLocation != LOCATION_DISABLED && mScreenOn;
+            final boolean aboveThreshold = isAboveThreshold(rxBytes, txBytes);
+
+            mSubMode = MODE_DOWNSTREAM_ONLY;
+            mIsActive = enabled && mAttached && (!mAutoHide || aboveThreshold);
+            mTrafficActive = (txBytes > 0 || rxBytes > 0);
 
             clearHandlerCallbacks();
 
             if (mIsActive) {
                 CharSequence output = "";
-                if (showUpstream && showDownstream) {
-                    if (mTxBytes > mRxBytes) {
-                        output = formatOutput(mTxBytes);
-                        submode = MODE_UPSTREAM_ONLY;
-                    } else if (mTxBytes < mRxBytes) {
-                        output = formatOutput(mRxBytes);
-                        submode = MODE_DOWNSTREAM_ONLY;
+
+                if (mMode != MODE_DOWNSTREAM_ONLY) {
+                    if (txBytes > rxBytes || mMode == MODE_UPSTREAM_ONLY) {
+                        output = formatOutput(txBytes);
+                        mSubMode = MODE_UPSTREAM_ONLY;
                     } else {
-                        output = formatOutput(mRxBytes);
-                        submode = MODE_UPSTREAM_AND_DOWNSTREAM;
+                        output = formatOutput(rxBytes);
+
+                        if (txBytes == rxBytes) {
+                            mSubMode = mMode;
+                        }
                     }
-                } else if (showDownstream) {
-                    output = formatOutput(mRxBytes);
-                } else if (showUpstream) {
-                    output = formatOutput(mTxBytes);
+                } else {
+                    output = formatOutput(rxBytes);
                 }
 
                 // Update view if there's anything new to show
                 if (output != getText()) {
                     setText(output);
                 }
+            } else {
+                setText("");
             }
 
             updateVisibility();
 
-            if (mVisible && mSubMode != submode) {
-                mSubMode = submode;
+            if (mVisible) {
                 setTrafficDrawable();
             }
 
@@ -268,29 +251,29 @@ public class NetworkTraffic extends TextView {
             if (speed >= Giga) {
                 unit = gunit;
                 decimalFormat = new DecimalFormat("0.00");
-                formatSpeed =  decimalFormat.format(speed / (float)Giga);
+                formatSpeed = decimalFormat.format(speed / (float)Giga);
             } else if (speed >= 100 * Mega) {
-                decimalFormat = new DecimalFormat("###0");
+                decimalFormat = new DecimalFormat("##0");
                 unit = munit;
-                formatSpeed =  decimalFormat.format(speed / (float)Mega);
+                formatSpeed = decimalFormat.format(speed / (float)Mega);
             } else if (speed >= 10 * Mega) {
                 decimalFormat = new DecimalFormat("#0.0");
                 unit = munit;
-                formatSpeed =  decimalFormat.format(speed / (float)Mega);
+                formatSpeed = decimalFormat.format(speed / (float)Mega);
             } else if (speed >= Mega) {
                 decimalFormat = new DecimalFormat("0.00");
                 unit = munit;
-                formatSpeed =  decimalFormat.format(speed / (float)Mega);
+                formatSpeed = decimalFormat.format(speed / (float)Mega);
             } else if (speed >= 100 * Kilo) {
                 decimalFormat = new DecimalFormat("##0");
                 unit = kunit;
-                formatSpeed =  decimalFormat.format(speed / (float)Kilo);
+                formatSpeed = decimalFormat.format(speed / (float)Kilo);
             } else if (speed >= 10 * Kilo) {
                 decimalFormat = new DecimalFormat("#0.0");
                 unit = kunit;
-                formatSpeed =  decimalFormat.format(speed / (float)Kilo);
+                formatSpeed = decimalFormat.format(speed / (float)Kilo);
             } else {
-                decimalFormat = new DecimalFormat("0.00");
+                decimalFormat = new DecimalFormat("0.##");
                 unit = kunit;
                 formatSpeed = decimalFormat.format(speed / (float)Kilo);
             }
@@ -303,10 +286,45 @@ public class NetworkTraffic extends TextView {
                     Spanned.SPAN_INCLUSIVE_INCLUSIVE);
             return TextUtils.concat(spanSpeedString, "\n", spanUnitString);
         }
+
+        private boolean isAboveThreshold(long rxBytes, long txBytes) {
+            final long rxKB = (long)rxBytes / Kilo;
+            final long txKB = (long)txBytes / Kilo;
+            final boolean showUpstream =
+                    mMode == MODE_UPSTREAM_ONLY || mMode == MODE_UPSTREAM_AND_DOWNSTREAM;
+            final boolean showDownstream =
+                    mMode == MODE_DOWNSTREAM_ONLY || mMode == MODE_UPSTREAM_AND_DOWNSTREAM;
+
+            return isConnectionAvailable() &&
+                   (showDownstream && rxKB > mAutoHideThreshold) ||
+                   (showUpstream && txKB > mAutoHideThreshold);
+        }
+
+        private long[] getTotalRxTxBytes() {
+            long[] bytes = new long[] { 0, 0 };
+
+            // Sum tx and rx bytes from all sources of interest
+            // Add stats
+            bytes[0] = TrafficStats.getTotalRxBytes();
+            bytes[1] = TrafficStats.getTotalTxBytes();
+
+            // Add tether hw offload counters since these are
+            // not included in netd interface stats.
+            final TetheringStats tetheringStats = getOffloadTetheringStats();
+            bytes[0] += tetheringStats.rxBytes;
+            bytes[1] += tetheringStats.txBytes;
+
+            if (DEBUG) {
+                Log.d(TAG, "tether hw offload txBytes: " + tetheringStats.txBytes
+                        + " rxBytes: " + tetheringStats.rxBytes);
+            }
+
+            return bytes;
+        }
     };
 
     protected void updateVisibility() {
-        boolean enabled = mIsActive && (mLocation == 2) && mScreenOn && getText() != "";
+        boolean enabled = mIsActive && (mLocation == LOCATION_QUICK_STATUSBAR) && mScreenOn && getText() != "";
         if (enabled != mVisible) {
             mVisible = enabled;
             setVisibility(mVisible ? VISIBLE : GONE);
@@ -439,23 +457,18 @@ public class NetworkTraffic extends TextView {
         mHideArrows = LineageSettings.Secure.getIntForUser(resolver,
                 LineageSettings.Secure.NETWORK_TRAFFIC_HIDEARROW, 0, UserHandle.USER_CURRENT) == 1;
 
-        if (!mHideArrows) {
-            setGravity(Gravity.END|Gravity.CENTER_VERTICAL);
-        } else {
-            setGravity(Gravity.CENTER);
-        }
-        setLines(2);
-        String txtFont = getResources().getString(com.android.internal.R.string.config_bodyFontFamily);
+        setGravity(Gravity.CENTER);
+        setMaxLines(2);
+        String txtFont = getResources().getString(com.android.internal.R.string.config_headlineFontFamilyMedium);
         setTypeface(Typeface.create(txtFont, Typeface.BOLD));
-        setLineSpacing(0.80f, 0.80f);
-        setStaticHeight(true);
+        setLineSpacing(0.75f, 0.75f);
 
         setTrafficDrawable();
         updateViews();
     }
 
     protected void updateViews() {
-        if (mLocation == 2 && mScreenOn) {
+        if (mLocation == LOCATION_QUICK_STATUSBAR && mScreenOn) {
             updateViewState();
         } else {
             clearHandlerCallbacks();
@@ -474,26 +487,24 @@ public class NetworkTraffic extends TextView {
     }
 
     protected void setTrafficDrawable() {
-        final int drawableResId;
-        final Resources resources = getResources();
+        int drawableResId = 0;
         final Drawable drawable;
 
-        if (!mHideArrows && mMode == MODE_UPSTREAM_AND_DOWNSTREAM) {
-            if (mSubMode == MODE_DOWNSTREAM_ONLY) {
-                drawableResId = R.drawable.stat_sys_network_traffic_down;
-            } else if (mSubMode == MODE_UPSTREAM_ONLY) {
-                drawableResId = R.drawable.stat_sys_network_traffic_up;
+        if (!mHideArrows) {
+            if (mTrafficActive) {
+                if (mSubMode == MODE_UPSTREAM_ONLY) {
+                    drawableResId = R.drawable.stat_sys_network_traffic_up;
+                } else if (mSubMode == MODE_DOWNSTREAM_ONLY) {
+                    drawableResId = R.drawable.stat_sys_network_traffic_down;
+                } else {
+                    drawableResId = R.drawable.stat_sys_network_traffic_updown;
+                }
             } else {
-                drawableResId = R.drawable.stat_sys_network_traffic_updown;
+                drawableResId = R.drawable.stat_sys_network_traffic;
             }
-        } else if (!mHideArrows && mMode == MODE_UPSTREAM_ONLY) {
-            drawableResId = R.drawable.stat_sys_network_traffic_up;
-        } else if (!mHideArrows && mMode == MODE_DOWNSTREAM_ONLY) {
-            drawableResId = R.drawable.stat_sys_network_traffic_down;
-        } else {
-            drawableResId = 0;
         }
-        drawable = drawableResId != 0 ? resources.getDrawable(drawableResId) : null;
+
+        drawable = drawableResId != 0 ? getResources().getDrawable(drawableResId) : null;
         if (mDrawable != drawable || mIconTint != newTint) {
             mDrawable = drawable;
             mIconTint = newTint;

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/StatusBarNetworkTraffic.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/StatusBarNetworkTraffic.java
@@ -49,7 +49,6 @@ public class StatusBarNetworkTraffic extends NetworkTraffic implements DarkRecei
 
     public StatusBarNetworkTraffic(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-        setVisibleState(STATE_ICON);
     }
 
     @Override
@@ -79,7 +78,7 @@ public class StatusBarNetworkTraffic extends NetworkTraffic implements DarkRecei
 
     @Override
     public boolean isIconVisible() {
-        return mLocation == 1;
+        return mLocation == 1; // LOCATION_DISABLED = 0, LOCATION_STATUSBAR = 1, LOCATION_QUICK_STATUSBAR = 2
     }
 
     @Override


### PR DESCRIPTION
 * Improve code readability.
 * Put getting total Rx/Tx data in a function.
 * Wrap checking for aboveThreshold in a function,
   also convert speed to Kilo/Speed before check.
 * Simplify handleMessage() & setTrafficDrawable().
   Since we are not showing 2 way traffic together
   anymore, there is no point for this if/else checks.
 * Remove an extra # from 100 * Mega check, we will
   show speed in Giga if speed is >999 Mega anyway.
 * Modify "0.00" pattern to "0.##" for Kilo speed scale.
   This will show "0 KB/s" instead of "0.00 KB/s".
 * Use more subtle traffic indicator icons.
 * Add indicator icon for 0 speed traffic.
 * Add padding for indicator icons.
 * Remove intricate mSubmode/submode logic.
   Since logic already exist for checking drawable,
   this is not needed.
 * Use "headlineFontFamilyMedium" font.
 * Implement logic to detect 0 speed traffic.
 * Use setMaxLines() instead of setLines().
 * Fix unit string for Kilobits/Kilobytes.

Signed-off-by: Gobinda Joy <gobinda.joy@gmail.com>