### PR TITLE
Disable SBC Dual Channel (SBC HD Audio) by default

### DIFF
--- a/core/res/res/values/cr_config.xml
+++ b/core/res/res/values/cr_config.xml
@@ -139,5 +139,5 @@
     <bool name="config_targetUsesInKernelDimming">true</bool>
 
     <!-- SBC Dual Channel (SBC HD Audio) -->
-    <bool name="config_enableSBCDualChannelAudio">true</bool>
+    <bool name="config_enableSBCDualChannelAudio">false</bool>
 </resources>


### PR DESCRIPTION
Not all devices may be ready for this.

To enable set config_enableSBCDualChannelAudio to true in device tree overlay.