### PR TITLE
services: LightsService: Mute an annoying error message.

### DIFF
--- a/services/core/jni/com_android_server_lights_LightsService.cpp
+++ b/services/core/jni/com_android_server_lights_LightsService.cpp
@@ -112,7 +112,7 @@ static void processReturn(
         case Status::SUCCESS:
             break;
         case Status::LIGHT_NOT_SUPPORTED:
-            ALOGE("Light requested not available on this device. %d", type);
+            ALOGV("Light requested not available on this device. %d", type);
             break;
         case Status::BRIGHTNESS_NOT_SUPPORTED:
             ALOGE("Brightness parameter not supported on this device: %d",


### PR DESCRIPTION
E LightsService: Light requested not available on this device. 2

If you google for the error you will find many discussion threads or logcats
that show this error. Since the error only describes that the device does
not support this function, the error can be classified as harmless. In order
not to confuse the user, we will now hide the logging of this error.

Signed-off-by: spezi77 <spezi7713@gmx.net>
Change-Id: I1bd004b8337e09ad1f20592a8f8628cec04b58c2