### PR TITLE
PocketJudge: allow register vendor pocket sensor

### DIFF
--- a/core/res/res/values/cr_config.xml
+++ b/core/res/res/values/cr_config.xml
@@ -141,4 +141,7 @@
     <!-- Defines the sysfs attribute path used by the device
          to enable/disable DC dimming. -->
     <string name="config_deviceDcDimmingSysfsNode"></string>
+
+    <!-- Defines custom OEM sensor for pocket detection. -->
+    <string name="config_pocketJudgeVendorSensorName"></string>
 </resources>

--- a/core/res/res/values/cr_symbols.xml
+++ b/core/res/res/values/cr_symbols.xml
@@ -196,6 +196,9 @@
   <java-symbol type="string" name="app_clipboard_access_denied" />
   <java-symbol type="string" name="app_clipboard_access_granted" />
 
-   <!-- DC Dimming -->
-   <java-symbol type="string" name="config_deviceDcDimmingSysfsNode" />
+  <!-- DC Dimming -->
+  <java-symbol type="string" name="config_deviceDcDimmingSysfsNode" />
+
+  <!-- Pocket Service -->
+  <java-symbol type="string" name="config_pocketJudgeVendorSensorName" />
 </resources>


### PR DESCRIPTION
Some devices (ie OnePlus) have own pocket sensor. This change allow to use
native pocket sensor instead of proximity and light.

Sensor name must be specified in device tree overlay.
In this case PocketService will try to use vendor sensor first.
If sensor wasn't found, fallback sensors (proximity and light) will be in use.

Example for OnePlus sensor:
<string name="config_pocketJudgeVendorSensorName">oneplus.sensor.pocket</string>

Change-Id: Ibe423478cfd9d49e0831e2df0af793178f62c0e0
Signed-off-by: DennySPb <dennyspb@gmail.com>
Signed-off-by: mracar07 <umutcan@umutcanacar.me>