### PR TITLE
base: Allow switching to drawable for qs icons

### DIFF
--- a/packages/SystemUI/res/values/lineage_config.xml
+++ b/packages/SystemUI/res/values/lineage_config.xml
@@ -28,4 +28,8 @@
          the sensor embedded in the power key and listening all the time
          causes a poor experience. -->
     <bool name="config_fingerprintWakeAndUnlock">true</bool>
+
+    <!-- Whether to use the mask for the quicksettings icons-->
+    <bool name="config_useMaskForQs">true</bool>
+
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/qs/tileimpl/QSTileBaseView.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tileimpl/QSTileBaseView.java
@@ -91,19 +91,24 @@ public class QSTileBaseView extends com.android.systemui.plugins.qs.QSTileView {
         int size = context.getResources().getDimensionPixelSize(R.dimen.qs_quick_tile_size);
         addView(mIconFrame, new LayoutParams(size, size));
         mBg = new ImageView(getContext());
-        Path path = new Path(PathParser.createPathFromPathData(
-                context.getResources().getString(ICON_MASK_ID)));
-        float pathSize = AdaptiveIconDrawable.MASK_SIZE;
-        PathShape p = new PathShape(path, pathSize, pathSize);
-        ShapeDrawable d = new ShapeDrawable(p);
-        d.setTintList(ColorStateList.valueOf(Color.TRANSPARENT));
-        int bgSize = context.getResources().getDimensionPixelSize(R.dimen.qs_tile_background_size);
-        d.setIntrinsicHeight(bgSize);
-        d.setIntrinsicWidth(bgSize);
-        mBg.setImageDrawable(d);
-        FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(bgSize, bgSize, Gravity.CENTER);
-        mIconFrame.addView(mBg, lp);
-        mBg.setLayoutParams(lp);
+        if (context.getResources().getBoolean(R.bool.config_useMaskForQs)) {
+            Path path = new Path(PathParser.createPathFromPathData(
+                    context.getResources().getString(ICON_MASK_ID)));
+            float pathSize = AdaptiveIconDrawable.MASK_SIZE;
+            PathShape p = new PathShape(path, pathSize, pathSize);
+            ShapeDrawable d = new ShapeDrawable(p);
+            d.setTintList(ColorStateList.valueOf(Color.TRANSPARENT));
+            int bgSize = context.getResources().getDimensionPixelSize(R.dimen.qs_tile_background_size);
+            d.setIntrinsicHeight(bgSize);
+            d.setIntrinsicWidth(bgSize);
+            mBg.setImageDrawable(d);
+            FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(bgSize, bgSize, Gravity.CENTER);
+            mIconFrame.addView(mBg, lp);
+            mBg.setLayoutParams(lp);
+        } else {
+            mBg.setImageResource(R.drawable.ic_qs_circle);
+            mIconFrame.addView(mBg);
+        }
         mIcon = icon;
         FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT,


### PR DESCRIPTION
* From 10 , google decided to use a mask for the quicksettings to support their shapes , this commit allows us to use the drawable for the qs icons to use in our qs styles

Signed-off-by: Simrat Singh <simrats169169@gmail.com>
Signed-off-by: Emma <slicey2001@gmail.com>
Change-Id: Ic3fe2f17572beb5921e276c52bdd0e45c45f6815