### PR TITLE
overlays: Fix inactive state Wifi Icon in Circular and Filled icon pack

### DIFF
--- a/packages/overlays/IconPackCircularAndroidOverlay/res/drawable/ic_wifi_signal_0.xml
+++ b/packages/overlays/IconPackCircularAndroidOverlay/res/drawable/ic_wifi_signal_0.xml
@@ -20,27 +20,19 @@
     android:viewportWidth="24"
     android:width="24dp" >
     <path
-        android:fillAlpha="0.3"
         android:fillColor="@android:color/white"
         android:pathData="M 12 17 C 12.8284271247 17 13.5 17.6715728753 13.5 18.5 C 13.5 19.3284271247 12.8284271247 20 12 20 C 11.1715728753 20 10.5 19.3284271247 10.5 18.5 C 10.5 17.6715728753 11.1715728753 17 12 17 Z"
-        android:strokeAlpha="0.3"
         android:strokeWidth="1" />
     <path
-        android:fillAlpha="0.3"
         android:fillColor="@android:color/white"
         android:pathData="M19.42,11.84c-0.19,0-0.38-0.07-0.53-0.22C17.05,9.77,14.6,8.75,12,8.75s-5.05,1.02-6.89,2.86 c-0.29,0.29-0.77,0.29-1.06,0c-0.29-0.29-0.29-0.77,0-1.06C6.17,8.43,9,7.25,12,7.25s5.83,1.17,7.95,3.3 c0.29,0.29,0.29,0.77,0,1.06C19.8,11.76,19.61,11.84,19.42,11.84z"
-        android:strokeAlpha="0.3"
         android:strokeWidth="1" />
     <path
-        android:fillAlpha="0.3"
         android:fillColor="@android:color/white"
         android:pathData="M22.61,8.65c-0.19,0-0.38-0.07-0.53-0.22C19.38,5.74,15.81,4.25,12,4.25S4.62,5.74,1.92,8.43c-0.29,0.29-0.77,0.29-1.06,0 s-0.29-0.77,0-1.06C3.84,4.39,7.79,2.75,12,2.75s8.16,1.64,11.14,4.61c0.29,0.29,0.29,0.77,0,1.06 C22.99,8.57,22.8,8.65,22.61,8.65z"
-        android:strokeAlpha="0.3"
         android:strokeWidth="1" />
     <path
-        android:fillAlpha="0.3"
         android:fillColor="@android:color/white"
         android:pathData="M16.25,15c-0.19,0-0.38-0.07-0.53-0.22c-1-0.99-2.32-1.53-3.73-1.53c-1.41,0-2.73,0.54-3.73,1.53 c-0.29,0.29-0.77,0.29-1.06-0.01c-0.29-0.29-0.29-0.77,0.01-1.06c1.28-1.27,2.98-1.96,4.78-1.96c1.8,0,3.5,0.7,4.78,1.96 c0.29,0.29,0.3,0.77,0.01,1.06C16.64,14.93,16.45,15,16.25,15z"
-        android:strokeAlpha="0.3"
         android:strokeWidth="1" />
 </vector>

--- a/packages/overlays/IconPackFilledAndroidOverlay/res/drawable/ic_wifi_signal_0.xml
+++ b/packages/overlays/IconPackFilledAndroidOverlay/res/drawable/ic_wifi_signal_0.xml
@@ -20,9 +20,7 @@
     android:viewportWidth="24"
     android:width="24dp" >
     <path
-        android:fillAlpha="0.3"
         android:fillColor="@android:color/white"
         android:pathData="M23.66,8.11c0.39-0.48,0.29-1.19-0.22-1.54C21.67,5.36,17.55,3,12,3C6.44,3,2.33,5.36,0.56,6.57 C0.05,6.92-0.05,7.63,0.33,8.11L11.16,21.6c0.42,0.53,1.23,0.53,1.66,0L23.66,8.11z"
-        android:strokeAlpha="0.3"
         android:strokeWidth="1" />
 </vector>


### PR DESCRIPTION
Signed-off-by: Aman Singh <amankumarsingh1412@gmail.com>