### PR TITLE
SystemUI: Don't shift KeyguardSecurityContainer when FOD isn't available

### DIFF
--- a/packages/SystemUI/src/com/android/keyguard/KeyguardSecurityContainer.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardSecurityContainer.java
@@ -525,10 +525,9 @@ public class KeyguardSecurityContainer extends FrameLayout implements KeyguardSe
 
         // Consume bottom insets because we're setting the padding locally (for IME and navbar.)
         int inset;
-        int minBottomMargin = mHasFod && !mUpdateMonitor.userNeedsStrongAuth() &&
-                mUpdateMonitor.isFingerprintDetectionRunning() ?
-                        getResources().getDimensionPixelSize(
-                                R.dimen.kg_security_container_min_bottom_margin) : 0;
+        int minBottomMargin = mHasFod && mUpdateMonitor.isFingerprintDetectionRunning() ?
+                getResources().getDimensionPixelSize(
+                        R.dimen.kg_security_container_min_bottom_margin) : 0;
 
         if (sNewInsetsMode == NEW_INSETS_MODE_FULL) {
             int bottomInset = insets.getInsetsIgnoringVisibility(systemBars()).bottom;


### PR DESCRIPTION
Tests:
    -removed enrolled fp, ensured keyguardsecuritycontainer wasn't shifed
    -removed enrolled fp, rebooted, ensured keyguardsecuritycontainer (on SIM PIN) wasn't shifted

Change-Id: Iccf469fa4fed79ff0edde014ba165eef6ee024e1
