### PR TITLE
Phone ringtone setting for Multi SIM device

### DIFF
--- a/media/java/android/media/MediaPlayer.java
+++ b/media/java/android/media/MediaPlayer.java
@@ -1063,7 +1063,8 @@ public class MediaPlayer extends PlayerBase
             // Try cached ringtone first since the actual provider may not be
             // encryption aware, or it may be stored on CE media storage
             final int type = RingtoneManager.getDefaultType(uri);
-            final Uri cacheUri = RingtoneManager.getCacheForType(type, context.getUserId());
+            final Uri cacheUri = RingtoneManager.getCacheForType(context, type,
+                    context.getUserId());
             final Uri actualUri = RingtoneManager.getActualDefaultRingtoneUri(context, type);
             if (attemptDataSource(resolver, cacheUri)) {
                 return;

--- a/media/java/android/media/RingtoneManager.java
+++ b/media/java/android/media/RingtoneManager.java
@@ -49,6 +49,11 @@ import android.provider.MediaStore;
 import android.provider.MediaStore.MediaColumns;
 import android.provider.Settings;
 import android.provider.Settings.System;
+import android.telecom.PhoneAccount;
+import android.telecom.PhoneAccountHandle;
+import android.telecom.TelecomManager;
+import android.telephony.SubscriptionManager;
+import android.telephony.TelephonyManager;
 import android.util.Log;
 
 import com.android.internal.database.SortCursor;
@@ -264,6 +269,9 @@ public class RingtoneManager {
 
     private boolean mIncludeParentRingtones;
 
+    private static final String EMERGENCY_PHONE_ACCOUNT_HANDLE_ID = "E";
+    private static final String RINGTONE_DELIMITER_FOR_PHONE_ACCOUNT_HANDLE = "_";
+    
     /**
      * Constructs a RingtoneManager. This constructor is recommended as its
      * constructed instance manages cursor(s).
@@ -777,7 +785,7 @@ public class RingtoneManager {
      * Gets the current default sound's {@link Uri}. This will give the actual
      * sound {@link Uri}, instead of using this, most clients can use
      * {@link System#DEFAULT_RINGTONE_URI}.
-     * 
+     *
      * @param context A context used for querying.
      * @param type The type whose default sound should be returned. One of
      *            {@link #TYPE_RINGTONE}, {@link #TYPE_NOTIFICATION}, or
@@ -786,10 +794,36 @@ public class RingtoneManager {
      * @see #setActualDefaultRingtoneUri(Context, int, Uri)
      */
     public static Uri getActualDefaultRingtoneUri(Context context, int type) {
-        String setting = getSettingForType(type);
+        return getActualDefaultRingtoneUriForPhoneAccountHandle(context, type, null);
+    }
+
+    /**
+     * Gets the current default sound's {@link Uri} by {@link PhoneAccountHandle}.
+     * This will give the actual sound {@link Uri}, instead of using this, most clients can use
+     * {@link System#DEFAULT_RINGTONE_URI}.
+     *
+     * @param context A context used for querying.
+     * @param type The type whose default sound should be returned. One of
+     *            {@link #TYPE_RINGTONE}, {@link #TYPE_NOTIFICATION}, or
+     *            {@link #TYPE_ALARM}.
+     * @param phoneAccountHandle The {@link PhoneAccountHandle} whose default sound should be
+     *        returned.
+     * @return A {@link Uri} pointing to the default sound for the sound type.
+     * @see #setActualDefaultRingtoneUriForPhoneAccountHandle(Context, int, Uri, PhoneAccountHandle)
+     * @hide
+     */
+    public static Uri getActualDefaultRingtoneUriForPhoneAccountHandle(Context context, int type,
+            PhoneAccountHandle phoneAccountHandle) {
+        String setting = getSettingForTypeForPhoneAccountHandle(type, phoneAccountHandle);
         if (setting == null) return null;
-        final String uriString = Settings.System.getStringForUser(context.getContentResolver(),
+        String uriString = Settings.System.getStringForUser(context.getContentResolver(),
                 setting, context.getUserId());
+        // For TYPE_RINGTONE, if the uriString for targeted PhoneAccountHandle is null, try to
+        // use the default ringtone which is saved in Settings.System.RINGTONE.
+        if (uriString == null && type == TYPE_RINGTONE) {
+            uriString = Settings.System.getStringForUser(context.getContentResolver(),
+                    Settings.System.RINGTONE, context.getUserId());
+        }
         Uri ringtoneUri = uriString != null ? Uri.parse(uriString) : null;
 
         // If this doesn't verify, the user id must be kept in the uri to ensure it resolves in the
@@ -801,10 +835,10 @@ public class RingtoneManager {
 
         return ringtoneUri;
     }
-    
+
     /**
      * Sets the {@link Uri} of the default sound for a given sound type.
-     * 
+     *
      * @param context A context used for querying.
      * @param type The type whose default sound should be set. One of
      *            {@link #TYPE_RINGTONE}, {@link #TYPE_NOTIFICATION}, or
@@ -813,7 +847,26 @@ public class RingtoneManager {
      * @see #getActualDefaultRingtoneUri(Context, int)
      */
     public static void setActualDefaultRingtoneUri(Context context, int type, Uri ringtoneUri) {
-        String setting = getSettingForType(type);
+        // Change the default ringtone which is saved in Settings.System.RINGTONE.
+        setActualDefaultRingtoneUriForPhoneAccountHandle(context, type, ringtoneUri, null);
+    }
+
+    /**
+     * Sets the {@link Uri} of the default sound by {@link PhoneAccountHandle} for a given
+     * sound type.
+     *
+     * @param context A context used for querying.
+     * @param type The type whose default sound should be set. One of
+     *            {@link #TYPE_RINGTONE}, {@link #TYPE_NOTIFICATION}, or
+     *            {@link #TYPE_ALARM}.
+     * @param ringtoneUri A {@link Uri} pointing to the default sound to set.
+     * @param phoneAccountHandle The {@link PhoneAccountHandle} whose default sound should be set.
+     * @see #getActualDefaultRingtoneUriForPhoneAccountHandle(Context, int, PhoneAccountHandle)
+     * @hide
+     */
+    public static void setActualDefaultRingtoneUriForPhoneAccountHandle(Context context, int type,
+                Uri ringtoneUri, PhoneAccountHandle phoneAccountHandle) {
+        String setting = getSettingForTypeForPhoneAccountHandle(type, phoneAccountHandle);
         if (setting == null) return;
 
         final ContentResolver resolver = context.getContentResolver();
@@ -831,7 +884,8 @@ public class RingtoneManager {
         // Stream selected ringtone into cache so it's available for playback
         // when CE storage is still locked
         if (ringtoneUri != null) {
-            final Uri cacheUri = getCacheForType(type, context.getUserId());
+            final Uri cacheUri = getCacheForTypeForPhoneAccountHandle(type, context.getUserId(),
+                    phoneAccountHandle);
             try (InputStream in = openRingtone(context, ringtoneUri);
                     OutputStream out = resolver.openOutputStream(cacheUri)) {
                 FileUtils.copy(in, out);
@@ -841,6 +895,30 @@ public class RingtoneManager {
         }
     }
 
+
+    private static PhoneAccountHandle getDefaultPhoneAccountHandle(Context context) {
+        TelecomManager tm = (TelecomManager) context.getSystemService(Context.TELECOM_SERVICE);
+        PhoneAccountHandle defaultPhoneAccountHandle = tm.getUserSelectedOutgoingPhoneAccount();
+        PhoneAccount defaultPhoneAccount = tm.getPhoneAccount(defaultPhoneAccountHandle);
+        if (defaultPhoneAccountHandle == null
+                || !defaultPhoneAccount.hasCapabilities(PhoneAccount.CAPABILITY_SIM_SUBSCRIPTION)) {
+            List<PhoneAccountHandle> subscriptionAccountHandles = new ArrayList<>();
+            List<PhoneAccountHandle> accountHandles = tm.getCallCapablePhoneAccounts(true);
+            for (PhoneAccountHandle accountHandle : accountHandles) {
+                PhoneAccount phoneAccount = tm.getPhoneAccount(accountHandle);
+                // Emergency phone account also has CAPABILITY_SIM_SUBSCRIPTION, so should
+                // exclude it.
+                if (phoneAccount.hasCapabilities(PhoneAccount.CAPABILITY_SIM_SUBSCRIPTION)
+                        && !EMERGENCY_PHONE_ACCOUNT_HANDLE_ID.equals(accountHandle.getId())) {
+                    subscriptionAccountHandles.add(accountHandle);
+                }
+            }
+            defaultPhoneAccountHandle = subscriptionAccountHandles.size() > 0
+                    ? subscriptionAccountHandles.get(0) : null;
+        }
+        return defaultPhoneAccountHandle;
+    }
+    
     private static boolean isInternalRingtoneUri(Uri uri) {
         return isRingtoneUriInStorage(uri, MediaStore.Audio.Media.INTERNAL_CONTENT_URI);
     }
@@ -956,9 +1034,13 @@ public class RingtoneManager {
         }
     }
 
-    private static String getSettingForType(int type) {
+    private static String getSettingForTypeForPhoneAccountHandle(int type,
+            PhoneAccountHandle phoneAccountHandle) {
         if ((type & TYPE_RINGTONE) != 0) {
-            return Settings.System.RINGTONE;
+            return phoneAccountHandle == null
+                    ? Settings.System.RINGTONE
+                    : Settings.System.RINGTONE + RINGTONE_DELIMITER_FOR_PHONE_ACCOUNT_HANDLE
+                            + phoneAccountHandle.getId();
         } else if ((type & TYPE_NOTIFICATION) != 0) {
             return Settings.System.NOTIFICATION_SOUND;
         } else if ((type & TYPE_ALARM) != 0) {
@@ -969,14 +1051,26 @@ public class RingtoneManager {
     }
 
     /** {@hide} */
-    public static Uri getCacheForType(int type) {
-        return getCacheForType(type, UserHandle.getCallingUserId());
+    public static Uri getCacheForType(Context context, int type) {
+        return getCacheForTypeForPhoneAccountHandle(type, UserHandle.getCallingUserId(),
+                getDefaultPhoneAccountHandle(context));
     }
 
     /** {@hide} */
-    public static Uri getCacheForType(int type, int userId) {
+    public static Uri getCacheForType(Context context, int type, int userId) {
+        return getCacheForTypeForPhoneAccountHandle(type, userId,
+                getDefaultPhoneAccountHandle(context));
+    }
+
+    private static Uri getCacheForTypeForPhoneAccountHandle(int type, int userId,
+            PhoneAccountHandle phoneAccountHandle) {
         if ((type & TYPE_RINGTONE) != 0) {
-            return ContentProvider.maybeAddUserId(Settings.System.RINGTONE_CACHE_URI, userId);
+            Uri ringtoneUri = phoneAccountHandle == null
+                    ? Settings.System.RINGTONE_CACHE_URI
+                    : Settings.System.getUriFor(Settings.System.RINGTONE_CACHE
+                            + RINGTONE_DELIMITER_FOR_PHONE_ACCOUNT_HANDLE
+                            + phoneAccountHandle.getId());
+            return ContentProvider.maybeAddUserId(ringtoneUri, userId);
         } else if ((type & TYPE_NOTIFICATION) != 0) {
             return ContentProvider.maybeAddUserId(Settings.System.NOTIFICATION_SOUND_CACHE_URI,
                     userId);
@@ -1056,7 +1150,7 @@ public class RingtoneManager {
         // Try cached ringtone first since the actual provider may not be
         // encryption aware, or it may be stored on CE media storage
         final int type = getDefaultType(uri);
-        final Uri cacheUri = getCacheForType(type, context.getUserId());
+        final Uri cacheUri = getCacheForType(context, type, context.getUserId());
         final Uri actualUri = getActualDefaultRingtoneUri(context, type);
         final ContentResolver resolver = context.getContentResolver();
 

--- a/packages/SettingsLib/res/values/cm_strings.xml
+++ b/packages/SettingsLib/res/values/cm_strings.xml
@@ -22,4 +22,6 @@
     <string name="screen_zoom_summary_smaller">Smaller</string>
     <!-- Description for the screen zoom level that makes interface elements smallest. [CHAR LIMIT=24] -->
     <string name="screen_zoom_summary_smallest">Smallest</string>
+	
+	<string name="status_deep_sleep">(Deep sleep: %1$d%2$s)</string>
 </resources>

--- a/packages/SettingsLib/src/com/android/settingslib/deviceinfo/AbstractUptimePreferenceController.java
+++ b/packages/SettingsLib/src/com/android/settingslib/deviceinfo/AbstractUptimePreferenceController.java
@@ -26,6 +26,7 @@ import androidx.annotation.VisibleForTesting;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceScreen;
 
+import com.android.settingslib.R;
 import com.android.settingslib.core.AbstractPreferenceController;
 import com.android.settingslib.core.lifecycle.Lifecycle;
 import com.android.settingslib.core.lifecycle.LifecycleObserver;
@@ -89,7 +90,18 @@ public abstract class AbstractUptimePreferenceController extends AbstractPrefere
     }
 
     private void updateTimes() {
-        mUptime.setSummary(DateUtils.formatElapsedTime(SystemClock.elapsedRealtime() / 1000));
+        long ut = Math.max((SystemClock.elapsedRealtime() / 1000), 1);
+
+        float deepSleepRatio = Math.max((float) (SystemClock.elapsedRealtime() - SystemClock.uptimeMillis()), 0f)
+                / SystemClock.elapsedRealtime();
+        int deepSleepPercent = Math.round(deepSleepRatio * 100);
+
+        final StringBuilder summary = new StringBuilder();
+        summary.append(DateUtils.formatElapsedTime(SystemClock.elapsedRealtime() / 1000));
+        summary.append(" ");
+        summary.append(mContext.getString(R.string.status_deep_sleep, deepSleepPercent, "%"));
+
+        mUptime.setSummary(summary.toString());
     }
 
     private static class MyHandler extends Handler {


### PR DESCRIPTION
Add below changes for Multi SIM device phone ringtone.
1. Add api setActualDefaultRingtoneUriForPhoneAccountHandle to
set ringtone for specific PhoneAccountHandle.
2. Add api getActualDefaultRingtoneUriForPhoneAccountHandle to
get ringtone for specific PhoneAccountHandle.
3. Support saving ringtone cache for specific PhoneAccountHandle.