### PR TITLE
Optimize Status Bar Notification Icon Area [1/2]

### DIFF
--- a/packages/SystemUI/res/layout/status_bar.xml
+++ b/packages/SystemUI/res/layout/status_bar.xml
@@ -92,7 +92,8 @@
                     android:layout_height="match_parent"
                     android:layout_weight="1"
                     android:orientation="horizontal"
-                    android:clipChildren="false"/>
+                    android:clipChildren="false"
+                    android:paddingEnd="@dimen/notification_icon_area_padding_end"/>
 
             </LinearLayout>
         </FrameLayout>


### PR DESCRIPTION
Allow Status Bar Notification Icon Area to be reduced so that it doesn't overlap with center clock in Status Bar.