### PR TITLE
Optimize Status Bar Notification Area [2/2]

### DIFF
--- a/packages/SystemUI/res/values/cr_dimens.xml
+++ b/packages/SystemUI/res/values/cr_dimens.xml
@@ -106,4 +106,6 @@
     <dimen name="dismiss_all_button_margin_bottom">35dp</dimen>
     <dimen name="dismiss_all_button_width">55dp</dimen>
     <dimen name="dismiss_all_fab_src_size">24dp</dimen>
+    <!-- Status Bar Notification Icon Area -->
+    <dimen name="notification_icon_area_padding_end">0dp</dimen>
 </resources>


### PR DESCRIPTION
Allow Status Bar Notification Icon Area to be reduced so that it doesn't overlap with center clock in Status Bar.