### PR TITLE
base: Smart Pulldown [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5569,6 +5569,12 @@ public final class Settings {
         public static final String QS_DATAUSAGE = "qs_datausage";
 
         /**
+         * Quick Settings Smart Pulldown
+         * @hide
+         */
+        public static final String QS_SMART_PULLDOWN = "qs_smart_pulldown";
+
+        /**
          * Keys we no longer back up under the current schema, but want to continue to
          * process when restoring historical backup datasets.
          *

--- a/packages/SystemUI/res/values/cr_dimens.xml
+++ b/packages/SystemUI/res/values/cr_dimens.xml
@@ -126,4 +126,8 @@
 
     <!-- App Lock -->
     <dimen name="applock_icon_dimension">54dp</dimen>
+
+    <!-- Biometric Prompt -->
+    <dimen name="biometric_dialog_fod_margin">12dp</dimen>
+
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/biometrics/AuthContainerView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/AuthContainerView.java
@@ -20,6 +20,7 @@ import android.annotation.IntDef;
 import android.annotation.NonNull;
 import android.annotation.Nullable;
 import android.content.Context;
+import android.content.pm.ActivityInfo;
 import android.graphics.PixelFormat;
 import android.hardware.biometrics.BiometricAuthenticator;
 import android.hardware.biometrics.BiometricConstants;
@@ -467,7 +468,7 @@ public class AuthContainerView extends LinearLayout
         if (mBiometricView != null) {
             mBiometricView.restoreState(savedState);
         }
-        wm.addView(this, getLayoutParams(mWindowToken));
+        wm.addView(this, getLayoutParams(mWindowToken, mBiometricView.getHasFod()));
     }
 
     @Override
@@ -632,7 +633,7 @@ public class AuthContainerView extends LinearLayout
      * @param windowToken token for the window
      * @return
      */
-    public static WindowManager.LayoutParams getLayoutParams(IBinder windowToken) {
+    public static WindowManager.LayoutParams getLayoutParams(IBinder windowToken, boolean hasFod) {
         final int windowFlags = WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED
                 | WindowManager.LayoutParams.FLAG_SECURE;
         final WindowManager.LayoutParams lp = new WindowManager.LayoutParams(
@@ -645,6 +646,9 @@ public class AuthContainerView extends LinearLayout
         lp.setFitInsetsTypes(lp.getFitInsetsTypes() & ~WindowInsets.Type.ime());
         lp.setTitle("BiometricPrompt");
         lp.token = windowToken;
+        if (hasFod) {
+            lp.screenOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
+        }
         return lp;
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/notification/NotificationEntryManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/notification/NotificationEntryManager.java
@@ -800,6 +800,32 @@ public class NotificationEntryManager implements
         return mActiveNotifications.get(key);
     }
 
+        /**
+     * Return whether there are any visible notifications (i.e. without an error).
+     */
+    public boolean hasActiveVisibleNotifications() {
+        for (NotificationEntry e : mSortedAndFiltered) {
+            if (e.getContentView() != null) { // the view successfully inflated
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Return whether there are any ongoing notifications (that aren't errors).
+     */
+    public boolean hasActiveOngoingNotifications() {
+        for (NotificationEntry e : mSortedAndFiltered) {
+            if (e.getContentView() != null) { // the view successfully inflated
+                if (e.getSbn().isOngoing()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     /**
      * Gets the pending or visible notification entry with the given key. Returns null if
      * notification doesn't exist.

--- a/packages/SystemUI/src/com/android/systemui/statusbar/notification/collection/NotificationEntry.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/notification/collection/NotificationEntry.java
@@ -53,6 +53,7 @@ import android.os.SystemClock;
 import android.service.notification.NotificationListenerService.Ranking;
 import android.service.notification.SnoozeCriterion;
 import android.service.notification.StatusBarNotification;
+import android.view.View;
 import android.util.ArraySet;
 
 import androidx.annotation.NonNull;
@@ -493,6 +494,10 @@ public final class NotificationEntry extends ListEntry {
 
     public void setRowController(ExpandableNotificationRowController controller) {
         mRowController = controller;
+    }
+
+    public View getContentView() {
+        return getRow().getPrivateLayout().getContractedChild();
     }
 
     /**

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
@@ -198,6 +198,8 @@ public class NotificationPanelViewController extends PanelViewController {
 
     private static final String STATUS_BAR_QUICK_QS_PULLDOWN =
             "lineagesystem:" + LineageSettings.System.STATUS_BAR_QUICK_QS_PULLDOWN;
+    private static final String QS_SMART_PULLDOWN =
+            "system:" + Settings.System.QS_SMART_PULLDOWN;
     private static final String DOUBLE_TAP_SLEEP_GESTURE =
             "lineagesystem:" + LineageSettings.System.DOUBLE_TAP_SLEEP_GESTURE;
     private static final String DOUBLE_TAP_SLEEP_LOCKSCREEN =
@@ -503,6 +505,7 @@ public class NotificationPanelViewController extends PanelViewController {
     };
 
     private int mOneFingerQuickSettingsIntercept;
+    private int mQsSmartPullDown;
 
     @Inject
     public NotificationPanelViewController(NotificationPanelView view,
@@ -1414,6 +1417,13 @@ public class NotificationPanelViewController extends PanelViewController {
                 break;
         }
         showQsOverride &= mBarState == StatusBarState.SHADE;
+
+        if (mQsSmartPullDown == 1 && !hasActiveClearableNotifications()
+                || mQsSmartPullDown == 2 &&
+                !mEntryManager.hasActiveOngoingNotifications()
+                || mQsSmartPullDown == 3 && !mEntryManager.hasActiveVisibleNotifications()) {
+                showQsOverride = true;
+        }
 
         return !isQSEventBlocked() && (twoFingerDrag || showQsOverride
                 || stylusButtonClickDrag || mouseButtonClickDrag);
@@ -3738,6 +3748,7 @@ public class NotificationPanelViewController extends PanelViewController {
             mZenModeController.addCallback(mZenModeControllerCallback);
             mConfigurationController.addCallback(mConfigurationListener);
             mTunerService.addTunable(this, STATUS_BAR_QUICK_QS_PULLDOWN);
+            mTunerService.addTunable(this, QS_SMART_PULLDOWN);
             mTunerService.addTunable(this, DOUBLE_TAP_SLEEP_GESTURE);
             mTunerService.addTunable(this, DOUBLE_TAP_SLEEP_LOCKSCREEN);
             mTunerService.addTunable(this, LOCKSCREEN_STATUS_BAR);
@@ -3764,6 +3775,10 @@ public class NotificationPanelViewController extends PanelViewController {
             switch (key) {
                 case STATUS_BAR_QUICK_QS_PULLDOWN:
                     mOneFingerQuickSettingsIntercept =
+                            TunerService.parseInteger(newValue, 0);
+                    break;
+                case QS_SMART_PULLDOWN:
+                    mQsSmartPullDown =
                             TunerService.parseInteger(newValue, 0);
                     break;
                 case DOUBLE_TAP_SLEEP_GESTURE:


### PR DESCRIPTION
Rewritten by Beanstown106 for 6.0/7.0

previously the detection for ongoing/persistent notifications were not working
im not sure how long this has actually been broken but i cleaned things up a little bit
also put to use the isOngoing boolean and properly put to use the hasActiveVisibleNotifications boolean

current options now are off, no dismissable, no ongoing, and no notifications

Credits: kufikugel, HardCorePawn, acardinal
@mydongistiny: fixed for oreo

Change-Id: I627295eaa3b1f73503c0952d72f879e4ebe6e407
Signed-off-by: mydongistiny <jaysonedson@gmail.com>

Co-authored-by: Lars Greiss <kufikugel@googlemail.com>