### PR TITLE
FOD: allow user to disable night light when active [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5434,6 +5434,12 @@ public final class Settings {
          * @hide
          */
         public static final String FOD_COLOR = "fod_color";
+        
+        /**
+         * FOD night light
+         * @hide
+         */
+        public static final String FOD_NIGHT_LIGHT = "fod_night_light";
 
         /** @hide */
         public static final String BACK_GESTURE_HEIGHT = "back_gesture_height";

--- a/core/res/res/values/cr_config.xml
+++ b/core/res/res/values/cr_config.xml
@@ -74,6 +74,9 @@
 
     <!-- Default fod pressed color -->
     <integer name="config_fod_pressed_color">1</integer>
+    
+    <!-- NightLight FOD -->
+    <bool name="disable_fod_night_light">false</bool>
 
     <!-- Default value for FOD animation package resources -->
     <string name="config_fodAnimationPackage" translatable="false">com.crdroid.fod.animations</string>

--- a/core/res/res/values/cr_symbols.xml
+++ b/core/res/res/values/cr_symbols.xml
@@ -84,6 +84,9 @@
 
   <!-- Default fod pressed icon -->
   <java-symbol type="integer" name="config_fod_pressed_color" />
+  
+  <!-- NightLight FOD -->
+  <java-symbol type="bool" name="disable_fod_night_light"/>
 
   <!-- Default value for FOD animation package resources -->
   <java-symbol type="string" name="config_fodAnimationPackage" />

--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleViewImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleViewImpl.java
@@ -18,9 +18,15 @@ package com.android.systemui.biometrics;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.content.res.Resources;
+import android.hardware.display.ColorDisplayManager;
+import android.os.Handler;
+import android.os.SystemProperties;
+import android.provider.Settings;
 import android.util.Slog;
 import android.view.View;
 
+import com.android.internal.R;
 import com.android.internal.util.crdroid.FodUtils;
 
 import com.android.systemui.SystemUI;
@@ -44,6 +50,9 @@ public class FODCircleViewImpl extends SystemUI implements CommandQueue.Callback
     private final ArrayList<WeakReference<FODCircleViewImplCallback>>
             mCallbacks = new ArrayList<>();
     private final CommandQueue mCommandQueue;
+    private boolean mDisableNightMode;
+    private boolean mNightModeActive;
+    private int mAutoModeState;
 
     private boolean mIsFODVisible;
 
@@ -72,6 +81,7 @@ public class FODCircleViewImpl extends SystemUI implements CommandQueue.Callback
         } catch (RuntimeException e) {
             Slog.e(TAG, "Failed to initialize FODCircleView", e);
         }
+        mDisableNightMode = mContext.getResources().getBoolean(R.bool.disable_fod_night_light);
     }
 
     @Override
@@ -84,20 +94,33 @@ public class FODCircleViewImpl extends SystemUI implements CommandQueue.Callback
                 }
             }
             mIsFODVisible = true;
+            if (isNightLightEnabled()) {
+                disableNightMode();
+            }
             mFodCircleView.show();
         }
     }
 
+    private boolean isNightLightEnabled() {
+       return Settings.System.getInt(mContext.getContentResolver(),
+                Settings.System.FOD_NIGHT_LIGHT, mDisableNightMode ? 1 : 0) == 1;
+    }
+    
     @Override
     public void hideInDisplayFingerprintView() {
         if (mFodCircleView != null) {
+             if (isNightLightEnabled()) {
             for (int i = 0; i < mCallbacks.size(); i++) {
                 FODCircleViewImplCallback cb = mCallbacks.get(i).get();
                 if (cb != null) {
                     cb.onFODStatusChange(false);
                 }
             }
+        }
             mIsFODVisible = false;
+            if (isNightLightEnabled()) {
+                setNightMode(mNightModeActive, mAutoModeState);
+            }
             mFodCircleView.hide();
         }
     }
@@ -126,5 +149,22 @@ public class FODCircleViewImpl extends SystemUI implements CommandQueue.Callback
     private void sendUpdates(FODCircleViewImplCallback callback) {
         callback.onFODStart();
         callback.onFODStatusChange(mIsFODVisible);
+    }
+
+   private void disableNightMode() {
+        ColorDisplayManager colorDisplayManager = mContext.getSystemService(ColorDisplayManager.class);
+        mAutoModeState = colorDisplayManager.getNightDisplayAutoMode();
+        mNightModeActive = colorDisplayManager.isNightDisplayActivated();
+        colorDisplayManager.setNightDisplayActivated(false);
+    }
+
+    private void setNightMode(boolean activated, int autoMode) {
+        ColorDisplayManager colorDisplayManager = mContext.getSystemService(ColorDisplayManager.class);
+        colorDisplayManager.setNightDisplayAutoMode(0);
+        if (autoMode == 0) {
+            colorDisplayManager.setNightDisplayActivated(activated);
+        } else if (autoMode == 1 || autoMode == 2) {
+            colorDisplayManager.setNightDisplayAutoMode(autoMode);
+        }
     }
 }


### PR DESCRIPTION
Make this optional for some devices and config for default true on devices which weird light sensors on FOD
eg: OP7TPRO

Signed-off-by: Varun Date <date.varun123@gmail.com>