### PR TITLE
SystemUI: Use paddingStart for keyguard_carrier_text_margin

### DIFF
--- a/packages/SystemUI/res/layout/keyguard_status_bar.xml
+++ b/packages/SystemUI/res/layout/keyguard_status_bar.xml
@@ -68,7 +68,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:paddingTop="@dimen/status_bar_padding_top"
-        android:layout_marginStart="@dimen/keyguard_carrier_text_margin"
+        android:paddingStart="@dimen/keyguard_carrier_text_margin"
         android:layout_toStartOf="@id/system_icons_container"
         android:gravity="center_vertical"
         android:ellipsize="marquee"


### PR DESCRIPTION
* On some punch hole devices (like OnePlus 8), keyguard_carrier_text_margin doesn't take effect until a manually SystemUI restart, no matter how much value is set.
  After test, switch to paddingStart for keyguard_carrier_text_margin can easily fix this issue, without effecting other devices.