### PR TITLE
SettingsProvider: Resolve package name that requires permission

### DIFF
--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
@@ -2077,7 +2077,8 @@ public class SettingsProvider extends ContentProvider {
     private void enforceWritePermission(String permission) {
         if (getContext().checkCallingOrSelfPermission(permission)
                 != PackageManager.PERMISSION_GRANTED) {
-            throw new SecurityException("Permission denial: writing to settings requires:"
+            throw new SecurityException("Permission denial: " + resolveCallingPackage() 
+                    + " writing to settings requires:"
                     + permission);
         }
     }


### PR DESCRIPTION
* Google is confused between developer and magician. It assumed that developer will
  understand which app is complaining about not having permission using magic wand.

* Bonus after this patch - it turned out that Google itself required permission:

04-16 01:35:40.293 W/anzv    (3239): java.lang.SecurityException: Permission denial: com.google.android.gms writing to settings requires:android.permission.WRITE_DEVICE_CONFIG

Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>
