### PR TITLE
SystemUI: Add a tile to show power menu

### DIFF
--- a/packages/SystemUI/res/drawable/ic_qs_power_menu.xml
+++ b/packages/SystemUI/res/drawable/ic_qs_power_menu.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2021 The LineageOS Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24"
+        android:viewportHeight="24">
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M 16.56 5.44 L 15.11 6.89 C 16.84 7.94 18 9.83 18 12 C 18 13.591 17.367 15.118 16.243 16.243 C 15.118 17.367 13.591 18 12 18 C 10.409 18 8.882 17.367 7.757 16.243 C 6.633 15.118 6 13.591 6 12 C 6 9.83 7.16 7.94 8.88 6.88 L 7.44 5.44 C 5.36 6.88 4 9.28 4 12 C 4 14.121 4.843 16.157 6.343 17.657 C 7.843 19.157 9.879 20 12 20 C 14.121 20 16.157 19.157 17.657 17.657 C 19.157 16.157 20 14.121 20 12 C 20 9.28 18.64 6.88 16.56 5.44 M 13 3 L 11 3 L 11 13 L 13 13" />
+</vector>

--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -114,7 +114,7 @@
 
     <!-- Tiles native to System UI. Order should match "quick_settings_tiles_default" -->
     <string name="quick_settings_tiles_stock" translatable="false">
-        wifi,cell,battery,dnd,flashlight,rotation,bt,airplane,nfc,location,hotspot,inversion,saver,dark,work,cast,night,screenrecord,reverse,ambient_display,aod,dataswitch,caffeine,heads_up,livedisplay,powershare,profiles,reading_mode,sync,usb_tether,volume_panel,vpn,anti_flicker,weather,cpuinfo,fpsinfo,gaming,smartpixels,reboot,sound,compass,locale
+        wifi,cell,battery,dnd,flashlight,rotation,bt,airplane,nfc,location,hotspot,inversion,saver,dark,work,cast,night,screenrecord,reverse,ambient_display,aod,dataswitch,caffeine,heads_up,livedisplay,powershare,profiles,reading_mode,sync,usb_tether,powermenu,volume_panel,vpn,anti_flicker,weather,cpuinfo,fpsinfo,gaming,smartpixels,reboot,sound,compass,locale
     </string>
 
     <!-- The tiles to display in QuickSettings -->

--- a/packages/SystemUI/res/values/cr_strings.xml
+++ b/packages/SystemUI/res/values/cr_strings.xml
@@ -257,4 +257,7 @@
 
     <!-- Scrolling Screenshot string -->
     <string name="scrollss">Scroll</string>
+
+    <!-- Power menu QS tile -->
+    <string name="quick_settings_power_menu_label">Power menu</string>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/qs/tileimpl/QSFactoryImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tileimpl/QSFactoryImpl.java
@@ -52,6 +52,7 @@ import com.android.systemui.qs.tiles.LocationTile;
 import com.android.systemui.qs.tiles.LiveDisplayTile;
 import com.android.systemui.qs.tiles.NfcTile;
 import com.android.systemui.qs.tiles.NightDisplayTile;
+import com.android.systemui.qs.tiles.PowerMenuTile;
 import com.android.systemui.qs.tiles.PowerShareTile;
 import com.android.systemui.qs.tiles.ProfilesTile;
 import com.android.systemui.qs.tiles.ReadingModeTile;
@@ -108,6 +109,7 @@ public class QSFactoryImpl implements QSFactory {
     private final Provider<DataSwitchTile> mDataSwitchTileProvider;
     private final Provider<HeadsUpTile> mHeadsUpTileProvider;
     private final Provider<LiveDisplayTile> mLiveDisplayTileProvider;
+    private final Provider<PowerMenuTile> mPowerMenuTileProvider;
     private final Provider<PowerShareTile> mPowerShareTileProvider;
     private final Provider<ProfilesTile> mProfilesTileProvider;
     private final Provider<ReadingModeTile> mReadingModeTileProvider;
@@ -156,6 +158,7 @@ public class QSFactoryImpl implements QSFactory {
             Provider<DataSwitchTile> dataSwitchTileProvider,
             Provider<HeadsUpTile> headsUpTileProvider,
             Provider<LiveDisplayTile> liveDisplayTileProvider,
+            Provider<PowerMenuTile> powerMenuTileProvider,
             Provider<PowerShareTile> powerShareTileProvider,
             Provider<ProfilesTile> profilesTileProvider,
             Provider<ReadingModeTile> readingModeTileProvider,
@@ -200,6 +203,7 @@ public class QSFactoryImpl implements QSFactory {
         mDataSwitchTileProvider = dataSwitchTileProvider;
         mHeadsUpTileProvider = headsUpTileProvider;
         mLiveDisplayTileProvider = liveDisplayTileProvider;
+        mPowerMenuTileProvider = powerMenuTileProvider;
         mPowerShareTileProvider = powerShareTileProvider;
         mProfilesTileProvider = profilesTileProvider;
         mReadingModeTileProvider = readingModeTileProvider;
@@ -281,6 +285,8 @@ public class QSFactoryImpl implements QSFactory {
                 return mHeadsUpTileProvider.get();
             case "livedisplay":
                 return mLiveDisplayTileProvider.get();
+            case "powermenu":
+                return mPowerMenuTileProvider.get();
             case "powershare":
                 return mPowerShareTileProvider.get();
             case "profiles":

--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/PowerMenuTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/PowerMenuTile.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2021 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.qs.tiles;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.RemoteException;
+import android.service.quicksettings.Tile;
+import android.view.IWindowManager;
+import android.view.WindowManagerGlobal;
+
+import com.android.internal.logging.MetricsLogger;
+import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
+import com.android.systemui.plugins.qs.QSTile.BooleanState;
+import com.android.systemui.qs.QSHost;
+import com.android.systemui.qs.tileimpl.QSTileImpl;
+import com.android.systemui.R;
+
+import javax.inject.Inject;
+
+public class PowerMenuTile extends QSTileImpl<BooleanState> {
+
+    @Inject
+    public PowerMenuTile(QSHost host) {
+        super(host);
+    }
+
+    @Override
+    protected void handleClick() {
+        final IWindowManager wm = WindowManagerGlobal.getWindowManagerService();
+        try {
+            wm.showGlobalActions();
+        } catch (RemoteException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public Intent getLongClickIntent() {
+        return null;
+    }
+
+    @Override
+    protected void handleUpdateState(BooleanState state, Object arg) {
+        state.label = mContext.getString(R.string.quick_settings_power_menu_label);
+        state.icon = ResourceIcon.get(R.drawable.ic_qs_power_menu);
+        state.state = Tile.STATE_ACTIVE;
+    }
+
+    @Override
+    public CharSequence getTileLabel() {
+        return mContext.getString(R.string.quick_settings_power_menu_label);
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsEvent.CRDROID_SETTINGS;
+    }
+
+    @Override
+    public BooleanState newTileState() {
+        BooleanState state = new BooleanState();
+        state.handlesLongClick = false;
+        return state;
+    }
+
+    @Override
+    public void handleSetListening(boolean listening) {}
+}


### PR DESCRIPTION
* Following what swapsCAPS did for Volume tile, create a tile to show power menu that could come handy for people with accessibility probems over physic buttons.

Signed-off-by: DarkJoker360 <simoespo159@gmail.com>
Change-Id: Ie30470ad90ce9db8f7687b2db05ab3c58d20a53d