### PR TITLE
camera: Skip HFR checks for privileged apps.

### DIFF
--- a/core/java/android/hardware/camera2/utils/SurfaceUtils.java
+++ b/core/java/android/hardware/camera2/utils/SurfaceUtils.java
@@ -30,6 +30,11 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import android.app.ActivityThread;
+import android.os.SystemProperties;
+import android.text.TextUtils;
+
+
 /**
  * Various Surface utilities.
  */
@@ -157,7 +162,13 @@ public class SurfaceUtils {
                     + " the size must be 1 or 2");
         }
 
+        if (isPrivilegedApp()) {
+            //skip checks for privileged apps
+            return;
+        }
+
         List<Size> highSpeedSizes = null;
+
         if (fpsRange == null) {
             highSpeedSizes = Arrays.asList(config.getHighSpeedVideoSizes());
         } else {
@@ -209,4 +220,20 @@ public class SurfaceUtils {
         }
     }
 
+    private static boolean isPrivilegedApp() {
+        String packageName = ActivityThread.currentOpPackageName();
+        String packageList = SystemProperties.get("persist.camera.privapp.list");
+
+        if (packageList.length() > 0) {
+            TextUtils.StringSplitter splitter = new TextUtils.SimpleStringSplitter(',');
+            splitter.setString(packageList);
+            for (String str : splitter) {
+                if (packageName.equals(str)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
Issue: HAL3 supports HFR only if its greater than or equal
       to 120fps.

Fix: Skip the checks to allow HFR 60 and 90 fps in HAL3 for
     specific apps.
     The following property need to be set to allow these
     HFR configurations :
     adb shell setprop persist.camera.privapp.list <pack1,pack2,etc>

Change-Id: I5f3bc94bea60dbe03284de39cd4280f67df8b015
CRs-Fixed: 2258892