### PR TITLE
LockIcon: Fix drawable log warning

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/LockIcon.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/LockIcon.java
@@ -177,7 +177,7 @@ public class LockIcon extends KeyguardAffordanceView {
         int iconRes = isAnim ? getThemedAnimationResId(lockAnimIndex) : getIconForState(newState);
 
         if (!mDrawableCache.contains(iconRes)) {
-            mDrawableCache.put(iconRes, getResources().getDrawable(iconRes));
+            mDrawableCache.put(iconRes, mContext.getDrawable(iconRes));
         }
 
         return mDrawableCache.get(iconRes);


### PR DESCRIPTION
W Resources: Drawable com.android.systemui:anim/lock_unlock has unresolved theme attributes! Consider using Resources.getDrawable(int, Theme) or Context.getDrawable(int).
W Resources: java.lang.RuntimeException
W Resources: 	at android.content.res.Resources.getDrawable(Resources.java:899)
W Resources: 	at com.android.systemui.statusbar.phone.LockIcon.getIcon(LockIcon.java:180)
W Resources: 	at com.android.systemui.statusbar.phone.LockIcon.access$200(LockIcon.java:46)
W Resources: 	at com.android.systemui.statusbar.phone.LockIcon$1.onPreDraw(LockIcon.java:70)
W Resources: 	at android.view.ViewTreeObserver.dispatchOnPreDraw(ViewTreeObserver.java:1093)
W Resources: 	at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:3094)
W Resources: 	at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1948)
W Resources: 	at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:8182)
W Resources: 	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1046)
W Resources: 	at android.view.Choreographer.doCallbacks(Choreographer.java:869)
W Resources: 	at android.view.Choreographer.doFrame(Choreographer.java:803)
W Resources: 	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1031)
W Resources: 	at android.os.Handler.handleCallback(Handler.java:938)
W Resources: 	at android.os.Handler.dispatchMessage(Handler.java:99)
W Resources: 	at android.os.Looper.loop(Looper.java:223)
W Resources: 	at android.app.ActivityThread.main(ActivityThread.java:7664)
W Resources: 	at java.lang.reflect.Method.invoke(Native Method)
W Resources: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
W Resources: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)