### PR TITLE
AntiFlickerTile: Fix error in handleRefreshState

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/AntiFlickerTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/AntiFlickerTile.java
@@ -109,7 +109,11 @@ public class AntiFlickerTile extends QSTileImpl<BooleanState> {
 
     @Override
     protected void handleUpdateState(BooleanState state, Object arg) {
-        state.value = mLiveDisplay.isAntiFlickerEnabled();
+        try {
+            state.value = mLiveDisplay.isAntiFlickerEnabled();
+        } catch (NullPointerException e) {
+            state.value = false;
+        }
         state.icon = mIcon;
         state.contentDescription = mContext.getString(R.string.quick_settings_anti_flicker);
         state.state = (state.value ? Tile.STATE_ACTIVE : Tile.STATE_INACTIVE);
@@ -133,6 +137,7 @@ public class AntiFlickerTile extends QSTileImpl<BooleanState> {
         @Override
         public void onReceive(Context context, Intent intent) {
             updateConfig();
+            refreshState();
             unregisterReceiver();
         }
     };


### PR DESCRIPTION
W Tile.AntiFlickerTile: Error in handleRefreshState
W Tile.AntiFlickerTile: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean org.lineageos.platform.internal.display.DisplayHardwareController.isAntiFlickerEnabled()' on a null object reference
W Tile.AntiFlickerTile: 	at android.os.Parcel.createExceptionOrNull(Parcel.java:2379)
W Tile.AntiFlickerTile: 	at android.os.Parcel.createException(Parcel.java:2357)
W Tile.AntiFlickerTile: 	at android.os.Parcel.readException(Parcel.java:2340)
W Tile.AntiFlickerTile: 	at android.os.Parcel.readException(Parcel.java:2282)
W Tile.AntiFlickerTile: 	at lineageos.hardware.ILiveDisplayService$Stub$Proxy.isAntiFlickerEnabled(ILiveDisplayService.java:887)
W Tile.AntiFlickerTile: 	at lineageos.hardware.LiveDisplayManager.isAntiFlickerEnabled(LiveDisplayManager.java:513)
W Tile.AntiFlickerTile: 	at com.android.systemui.qs.tiles.AntiFlickerTile.handleUpdateState(AntiFlickerTile.java:114)
W Tile.AntiFlickerTile: 	at com.android.systemui.qs.tiles.AntiFlickerTile.handleUpdateState(AntiFlickerTile.java:40)
W Tile.AntiFlickerTile: 	at com.android.systemui.qs.tileimpl.QSTileImpl.handleRefreshState(QSTileImpl.java:410)
W Tile.AntiFlickerTile: 	at com.android.systemui.qs.tileimpl.QSTileImpl$H.handleMessage(QSTileImpl.java:620)
W Tile.AntiFlickerTile: 	at android.os.Handler.dispatchMessage(Handler.java:106)
W Tile.AntiFlickerTile: 	at android.os.Looper.loop(Looper.java:223)
W Tile.AntiFlickerTile: 	at android.os.HandlerThread.run(HandlerThread.java:67)