### PR TITLE
PocketJudge: Allow to register vendor proximity sensor

### DIFF
--- a/core/res/res/values/cr_config.xml
+++ b/core/res/res/values/cr_config.xml
@@ -49,6 +49,7 @@
 
     <!-- Defines custom OEM sensor for pocket detection. -->
     <string name="config_pocketJudgeVendorSensorName"></string>
+    <string name="config_pocketJudgeVendorProximitySensorName"></string>
 
     <!-- Whether the device supports Smart Pixels -->
     <bool name="config_supportSmartPixels">false</bool>

--- a/core/res/res/values/cr_symbols.xml
+++ b/core/res/res/values/cr_symbols.xml
@@ -58,6 +58,7 @@
 
   <!-- Pocket Service -->
   <java-symbol type="string" name="config_pocketJudgeVendorSensorName" />
+  <java-symbol type="string" name="config_pocketJudgeVendorProximitySensorName" />
 
   <!-- Whether the device supports Smart Pixels -->
   <java-symbol type="bool" name="config_supportSmartPixels" />

--- a/services/core/java/com/android/server/pocket/PocketService.java
+++ b/services/core/java/com/android/server/pocket/PocketService.java
@@ -173,7 +173,13 @@ public class PocketService extends SystemService implements IBinder.DeathRecipie
         mSensorManager = (SensorManager) mContext.getSystemService(Context.SENSOR_SERVICE);
         mVendorPocketSensor = mContext.getResources().getString(
                         com.android.internal.R.string.config_pocketJudgeVendorSensorName);
-        mProximitySensor = mSensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);
+        String vendorProximitySensor = mContext.getResources().getString(
+                        com.android.internal.R.string.config_pocketJudgeVendorProximitySensorName);
+        if (vendorProximitySensor != null && !vendorProximitySensor.isEmpty()) {
+            mProximitySensor = getSensor(mSensorManager, vendorProximitySensor);
+        } else {
+            mProximitySensor = mSensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);
+        }
         if (mProximitySensor != null) {
             mProximityMaxRange = mProximitySensor.getMaximumRange();
         }


### PR DESCRIPTION
Some devices (ie OnePlus) have bunch of proximity sensors
and default one may not work properly. This change allow to use
particular proximity sensor.

Example for OnePlus infrared proximity sensor:
<string name="config_pocketJudgeVendorProximitySensorName">oneplus.sensor.infrared.proximity</string>