### PR TITLE
fixup - Allow devices to hide black fill-in for display cutout [1/2]

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/ScreenDecorations.java
+++ b/packages/SystemUI/src/com/android/systemui/ScreenDecorations.java
@@ -765,13 +765,16 @@ public class ScreenDecorations extends SystemUI implements Tunable,
 
     static boolean shouldDrawCutout(Context context) {
         ContentResolver cr = context.getContentResolver();
-        boolean hideNotch = cr != null && System.getIntForUser(cr,
+        Resources res = context.getResources();
+        boolean hideNotch = res.getBoolean(
+                        com.android.internal.R.bool.config_showHideNotchSettings)
+                        && cr != null && System.getIntForUser(cr,
                         System.DISPLAY_HIDE_NOTCH, 0, UserHandle.USER_CURRENT) != 0;
         if (hideNotch)
             return false;
         boolean newImmerseMode = cr != null && System.getIntForUser(cr,
                         System.DISPLAY_CUTOUT_MODE, 0, UserHandle.USER_CURRENT) != 0;
-        return !newImmerseMode && context.getResources().getBoolean(
+        return !newImmerseMode && res.getBoolean(
                 com.android.internal.R.bool.config_fillMainBuiltInDisplayCutout);
     }
 


### PR DESCRIPTION
Commit "Allow devices to hide black fill-in for display cutout [1/2]"
doesn't really hiding notch on OnePlus 7, but breaking overlay package.
To fix usage of notch hide overlay package check if config_showHideNotchSettings
is enabled on device.