### PR TITLE
Restore Dim_Behind Flag of Base View and set dim amount to 0.0f

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FODCircleView.java
@@ -347,7 +347,8 @@ public class FODCircleView extends ImageView implements TunerService.Tunable, Co
         mParams.type = WindowManager.LayoutParams.TYPE_SYSTEM_FINGERPRINT;
         mParams.flags = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE |
                 WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN |
-                WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH;
+                WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH |
+                WindowManager.LayoutParams.FLAG_DIM_BEHIND;
         mParams.gravity = Gravity.TOP | Gravity.LEFT;
 
         mPressedParams.copyFrom(mParams);
@@ -357,6 +358,8 @@ public class FODCircleView extends ImageView implements TunerService.Tunable, Co
 
         mParams.setTitle("Fingerprint on display");
         mPressedParams.setTitle("Fingerprint on display.touched");
+
+        mParams.dimAmount = 0.0f;
 
         mPressedView = new ImageView(context)  {
             @Override


### PR DESCRIPTION
This will fix problem onTouch of apparently boost brightness for xiaomi sm8250 fod implementation.
This will not fix totally the problem, if into lineage fod hal implementation write on
disp_param command to enable fod_hbm display function, to solve need concomitant use of composition engine.