### PR TITLE
[Enhancement] Added per app volume control to CrDroid

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -9953,6 +9953,12 @@ public final class Settings {
          */
         public static final String VOLUME_LINK_NOTIFICATION = "volume_link_notification";
 
+         /**
+         * Show app volume rows in volume panel
+         * @hide
+         */
+        public static final String SHOW_APP_VOLUME = "show_app_volume";
+
         /**
          * Select from different navigation bar layouts
          * @hide

--- a/core/jni/android_media_AudioSystem.cpp
+++ b/core/jni/android_media_AudioSystem.cpp
@@ -29,6 +29,7 @@
 #include <audiomanager/AudioManager.h>
 #include <media/AudioPolicy.h>
 #include <media/AudioSystem.h>
+#include <media/AppTrackData.h>
 #include <media/MicrophoneInfo.h>
 #include <nativehelper/ScopedLocalRef.h>
 #include <system/audio.h>
@@ -171,6 +172,9 @@ static struct {
     jmethodID postDynPolicyEventFromNative;
     jmethodID postRecordConfigEventFromNative;
 } gAudioPolicyEventHandlerMethods;
+
+static jclass gAppTrackDataClass;
+static jmethodID gAppTrackDataCstor;
 
 //
 // JNI Initialization for OpenSLES routing
@@ -761,6 +765,104 @@ android_media_AudioSystem_getMasterBalance(JNIEnv *env, jobject thiz)
         balance = 0.f;
     }
     return balance;
+}
+
+static jint
+android_media_AudioSystem_setAppVolume(JNIEnv *env, jobject thiz, jstring packageName, jfloat value)
+{
+    const jchar* c_packageName = env->GetStringCritical(packageName, 0);
+    String8 package8 = String8(reinterpret_cast<const char16_t*>(c_packageName), env->GetStringLength(packageName));
+    env->ReleaseStringCritical(packageName, c_packageName);
+    return (jint) check_AudioSystem_Command(AudioSystem::setAppVolume(package8, value));
+}
+
+static jint
+android_media_AudioSystem_setAppMute(JNIEnv *env, jobject thiz, jstring packageName, jboolean mute)
+{
+    const jchar* c_packageName = env->GetStringCritical(packageName, 0);
+    String8 package8 = String8(reinterpret_cast<const char16_t*>(c_packageName), env->GetStringLength(packageName));
+    env->ReleaseStringCritical(packageName, c_packageName);
+    return (jint) check_AudioSystem_Command(AudioSystem::setAppMute(package8, mute));
+}
+
+jint convertAppTrackDataFromNative(JNIEnv *env, jobject *jAppTrackData, const AppTrackData *AppTrackData)
+{
+    jint jStatus = (jint)AUDIO_JAVA_SUCCESS;
+    jstring jPackageName;
+    jfloat jVolume;
+    jboolean jMute;
+    jboolean jActive;
+
+    if (AppTrackData == NULL || jAppTrackData == NULL) {
+        jStatus = (jint)AUDIO_JAVA_ERROR;
+        goto exit;
+    }
+
+    jPackageName = env->NewStringUTF((*AppTrackData).packageName);
+    jVolume = (*AppTrackData).volume;
+    jMute = (*AppTrackData).muted;
+    jActive = (*AppTrackData).active;
+
+    *jAppTrackData = env->NewObject(gAppTrackDataClass, gAppTrackDataCstor,
+                                jPackageName, jMute, jVolume, jActive);
+
+    env->DeleteLocalRef(jPackageName);
+exit:
+    return jStatus;
+}
+
+static jint
+android_media_AudioSystem_listAppTrackDatas(JNIEnv *env, jobject clazz, jobject jVolumes)
+{
+    ALOGV("listAppTrackDatas");
+
+    if (jVolumes == NULL) {
+        ALOGE("listAppTrackDatas NULL AppTrackData ArrayList");
+        return (jint)AUDIO_JAVA_BAD_VALUE;
+    }
+    if (!env->IsInstanceOf(jVolumes, gArrayListClass)) {
+        ALOGE("listAppTrackDatas not an arraylist");
+        return (jint)AUDIO_JAVA_BAD_VALUE;
+    }
+
+    status_t status;
+    unsigned int numVolumes;
+    AppTrackData *nVolumes = NULL;
+    jint jStatus = (jint)AUDIO_JAVA_SUCCESS;
+
+    numVolumes = 0;
+    status = AudioSystem::listAppTrackDatas(&numVolumes, NULL);
+    if (status != NO_ERROR) {
+        ALOGE("AudioSystem::listAppTrackDatas error %d", status);
+        jStatus = nativeToJavaStatus(status);
+        goto exit;
+    }
+    if (numVolumes == 0) {
+        goto exit;
+    }
+    nVolumes = (AppTrackData *)realloc(nVolumes, numVolumes * sizeof(AppTrackData));
+
+    status = AudioSystem::listAppTrackDatas(&numVolumes, nVolumes);
+    jStatus = nativeToJavaStatus(status);
+    if (jStatus != AUDIO_JAVA_SUCCESS) {
+        goto exit;
+    }
+
+    for (size_t i = 0; i < numVolumes; i++) {
+        jobject jAppTrackData = NULL;
+        jStatus = convertAppTrackDataFromNative(env, &jAppTrackData, &nVolumes[i]);
+        if (jStatus != AUDIO_JAVA_SUCCESS) {
+            goto exit;
+        }
+        env->CallBooleanMethod(jVolumes, gArrayListMethods.add, jAppTrackData);
+        if (jAppTrackData != NULL) {
+            env->DeleteLocalRef(jAppTrackData);
+        }
+    }
+
+exit:
+    free(nVolumes);
+    return jStatus;
 }
 
 static jint
@@ -2561,7 +2663,13 @@ static const JNINativeMethod gMethods[] =
           (void *)android_media_AudioSystem_setUserIdDeviceAffinities},
          {"removeUserIdDeviceAffinities", "(I)I",
           (void *)android_media_AudioSystem_removeUserIdDeviceAffinities},
-         {"setCurrentImeUid", "(I)I", (void *)android_media_AudioSystem_setCurrentImeUid}};
+         {"setCurrentImeUid", "(I)I", (void *)android_media_AudioSystem_setCurrentImeUid}},
+         {"setAppVolume", "(Ljava/lang/String;F)I",
+          (void *)android_media_AudioSystem_setAppVolume},
+         {"setAppMute", "(Ljava/lang/String;Z)I",
+          (void *)android_media_AudioSystem_setAppMute},
+         {"listAppTrackDatas", "(Ljava/util/ArrayList;)I",
+          (void *)android_media_AudioSystem_listAppTrackDatas}};
 
 static const JNINativeMethod gEventHandlerMethods[] = {
     {"native_setup",
@@ -2652,6 +2760,11 @@ int register_android_media_AudioSystem(JNIEnv *env)
     gAudioPortFields.mType = GetFieldIDOrDie(env, audioDevicePortClass, "mType", "I");
     gAudioPortFields.mAddress = GetFieldIDOrDie(env, audioDevicePortClass, "mAddress",
             "Ljava/lang/String;");
+
+    jclass AppTrackDataClass = FindClassOrDie(env, "android/media/AppTrackData");
+    gAppTrackDataClass = MakeGlobalRefOrDie(env, AppTrackDataClass);
+    gAppTrackDataCstor = GetMethodIDOrDie(env, AppTrackDataClass, "<init>",
+            "(Ljava/lang/String;ZFZ)V");
 
     jclass audioMixPortClass = FindClassOrDie(env, "android/media/AudioMixPort");
     gAudioMixPortClass = MakeGlobalRefOrDie(env, audioMixPortClass);

--- a/media/java/android/media/AppTrackData.java
+++ b/media/java/android/media/AppTrackData.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 The exTHmUI Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.media;
+
+import android.annotation.NonNull;
+
+/**
+ * @hide
+ */
+public class AppTrackData {
+    private final String mPackageName;
+    private final float mVolume;
+    private final boolean mMute;
+    private final boolean mActive;
+
+    AppTrackData(String packageName, boolean mute, float volume, boolean active) {
+        mPackageName = packageName;
+        mMute = mute;
+        mVolume = volume;
+        mActive = active;
+    }
+
+    @NonNull
+    public String getPackageName() {
+        return mPackageName;
+    }
+
+    public float getVolume() {
+        return mVolume;
+    }
+
+    public boolean isMuted() {
+        return mMute;
+    }
+
+    public boolean isActive() {
+        return mActive;
+    }
+}

--- a/media/java/android/media/AudioManager.java
+++ b/media/java/android/media/AudioManager.java
@@ -939,6 +939,32 @@ public class AudioManager {
         }
     }
 
+    /** @hide */
+    @UnsupportedAppUsage
+    @RequiresPermission(android.Manifest.permission.MODIFY_AUDIO_ROUTING)
+    public int setAppVolume(String packageName, float volume) {
+        return AudioSystem.setAppVolume(packageName, volume);
+    }
+
+    /** @hide */
+    @UnsupportedAppUsage
+    @RequiresPermission(android.Manifest.permission.MODIFY_AUDIO_ROUTING)
+    public int setAppMute(String packageName, boolean mute) {
+        return AudioSystem.setAppMute(packageName, mute);
+    }
+
+    /** @hide */
+    @UnsupportedAppUsage
+    @RequiresPermission(android.Manifest.permission.MODIFY_AUDIO_ROUTING)
+    public ArrayList<AppTrackData> listAppTrackDatas() {
+        ArrayList<AppTrackData> volumes = new ArrayList<AppTrackData>();
+        int status = AudioSystem.listAppTrackDatas(volumes);
+        if (status != AudioManager.SUCCESS) {
+            return new ArrayList<AppTrackData>();
+        }
+        return volumes;
+    }
+
     /**
      * Returns the current ringtone mode.
      *

--- a/media/java/android/media/AudioSystem.java
+++ b/media/java/android/media/AudioSystem.java
@@ -1739,6 +1739,21 @@ public class AudioSystem
     public static native int getPreferredDeviceForStrategy(int strategy,
                                                            AudioDeviceAttributes[] device);
 
+    /**
+     * @hide
+     */
+    public static native int setAppVolume(@NonNull String packageName, float volume);
+
+    /**
+     * @hide
+     */
+    public static native int setAppMute(@NonNull String packageName, boolean mute);
+
+    /**
+     * @hide
+     */
+    public static native int listAppTrackDatas(ArrayList<AppTrackData> volumes);
+
     // Items shared with audio service
 
     /**

--- a/packages/SystemUI/res/layout/volume_dialog_row.xml
+++ b/packages/SystemUI/res/layout/volume_dialog_row.xml
@@ -51,6 +51,20 @@
 
             <com.android.systemui.statusbar.AlphaOptimizedImageView
                 android:id="@+id/volume_row_icon"
+                android:visibility="gone"
+                android:layout_width="@dimen/volume_dialog_row_icon_size"
+                android:layout_height="@dimen/volume_dialog_tap_target_size"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginBottom="-12dp"
+                android:clickable="false"
+                android:layoutDirection="ltr"
+                android:scaleType="fitCenter"
+                android:soundEffectsEnabled="false"
+                android:tint="?android:attr/colorAccent" />
+
+            <com.android.systemui.statusbar.AlphaOptimizedImageView
+                android:id="@+id/volume_row_app_icon"
+                android:visibility="gone"
                 android:layout_width="@dimen/volume_dialog_row_icon_size"
                 android:layout_height="@dimen/volume_dialog_tap_target_size"
                 android:layout_gravity="center_horizontal"
@@ -75,6 +89,7 @@
                 android:textAppearance="@style/TextAppearance.Volume.Header"
                 android:textColor="?android:attr/colorAccent"
                 android:textStyle="bold" />
+            
         </LinearLayout>
     </FrameLayout>
 

--- a/packages/SystemUI/res/values/dimens.xml
+++ b/packages/SystemUI/res/values/dimens.xml
@@ -467,6 +467,7 @@
     <dimen name="volume_tool_tip_arrow_margin_container">-2dp</dimen>
     <dimen name="volume_tool_tip_arrow_margin_start">24dp</dimen>
     <dimen name="volume_tool_tip_arrow_corner_radius">2dp</dimen>
+    <dimen name="volume_row_app_icon_padding">8dp</dimen>
 
     <!-- Gravity for the notification panel -->
     <integer name="notification_panel_layout_gravity">0x31</integer><!-- center_horizontal|top -->


### PR DESCRIPTION
Added changes for app vol rows feature to CrDroid ROM and most changes seem to be fine and match with the ROM code. 
Made these changes: 
SystemUI: add app volume row to volume dialog
Audio: support set volume for app
base: made app volume rows optional
ISSUE:
Had an issue adding code to VolumeDialogImpl.java. This class will need a revised version to match the java code. Need to add a way to add updateAppRows() method correctly when the volume panel is expanded.
Code was from cjybyjk when they tried to implement the feature to Evolution X. I take no credit for adding this feature as it was not my code and I just wanted to add this feature to CrDroid.
Credits:
@cjybyjk from Evolution X
Links:
https://github.com/Evolution-X/frameworks_base/commit/a508a0651b60a498d5832ac39eadcb0c8853182e
https://github.com/Evolution-X/frameworks_base/commit/d451f9a46318d813009276114c9afb531d792c1d
https://github.com/Evolution-X/frameworks_base/commit/9b3fd798d3d4f59f2b3863b63ec533e8a4422fcb