### PR TITLE
SystemUI: Implement burn-in protection for status/navbar

### DIFF
--- a/packages/SystemUI/res/values/cr_config.xml
+++ b/packages/SystemUI/res/values/cr_config.xml
@@ -45,4 +45,8 @@
     
     <!-- Whether to disable assist hint on lockscreen -->
     <bool name="config_disableAssistHintOnLockscreen">false</bool>
+
+    <!-- Burn in protection -->
+    <bool name="config_statusBarBurnInProtection">false</bool>
+    <integer name="config_shift_interval">60</integer>
 </resources>

--- a/packages/SystemUI/res/values/cr_dimens.xml
+++ b/packages/SystemUI/res/values/cr_dimens.xml
@@ -135,4 +135,8 @@
     <dimen name="ticker_top_padding">2dp</dimen>
     <dimen name="ticker_icon_end_margin">4dp</dimen>
     <dimen name="ticker_text_end_padding">10dp</dimen>
+
+    <!-- Burn-in protection -->
+    <dimen name="horizontal_max_swift">3.0dp</dimen>
+    <dimen name="vertical_max_swift">1.0dp</dimen>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NavigationBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NavigationBarView.java
@@ -178,6 +178,13 @@ public class NavigationBarView extends FrameLayout implements
     @Nullable
     private Rect mOrientedHandleSamplingRegion;
 
+    private int mBasePaddingBottom;
+    private int mBasePaddingLeft;
+    private int mBasePaddingRight;
+    private int mBasePaddingTop;
+
+    private ViewGroup mNavigationBarContents;
+
     private boolean mShowCursorKeys;
 
     private class NavTransitionListener implements TransitionListener {
@@ -960,6 +967,18 @@ public class NavigationBarView extends FrameLayout implements
         mRecentsOnboarding.hide(true);
     }
 
+    public void swiftNavigationBarItems(int horizontalShift, int verticalShift) {
+        if (mNavigationBarContents == null) {
+            return;
+        }
+
+        mNavigationBarContents.setPaddingRelative(mBasePaddingLeft + horizontalShift,
+                                              mBasePaddingTop + verticalShift,
+                                              mBasePaddingRight + horizontalShift,
+                                              mBasePaddingBottom - verticalShift);
+        invalidate();
+    }
+
     @Override
     public void onFinishInflate() {
         super.onFinishInflate();
@@ -970,6 +989,14 @@ public class NavigationBarView extends FrameLayout implements
 
         Divider divider = Dependency.get(Divider.class);
         divider.registerInSplitScreenListener(mDockedListener);
+
+        mNavigationBarContents = (ViewGroup) findViewById(R.id.nav_buttons);
+
+        mBasePaddingLeft = mNavigationBarContents.getPaddingStart();
+        mBasePaddingTop = mNavigationBarContents.getPaddingTop();
+        mBasePaddingRight = mNavigationBarContents.getPaddingEnd();
+        mBasePaddingBottom = mNavigationBarContents.getPaddingBottom();
+
         updateOrientationViews();
         reloadNavIcons();
     }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarView.java
@@ -23,6 +23,7 @@ import static java.lang.Float.isNaN;
 import android.annotation.Nullable;
 import android.content.Context;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.graphics.Rect;
 import android.os.RemoteException;
 import android.util.AttributeSet;
@@ -58,6 +59,13 @@ public class PhoneStatusBarView extends PanelBar implements Callbacks {
     private static final boolean DEBUG = StatusBar.DEBUG;
     private static final boolean DEBUG_GESTURES = false;
     private final CommandQueue mCommandQueue;
+
+    private int mBasePaddingBottom;
+    private int mBasePaddingLeft;
+    private int mBasePaddingRight;
+    private int mBasePaddingTop;
+
+    private ViewGroup mStatusBarContents;
 
     StatusBar mBar;
 
@@ -131,11 +139,30 @@ public class PhoneStatusBarView extends PanelBar implements Callbacks {
         mScrimController = scrimController;
     }
 
+    public void swiftStatusBarItems(int horizontalShift, int verticalShift) {
+        if (mStatusBarContents == null) {
+            return;
+        }
+
+        mStatusBarContents.setPaddingRelative(mBasePaddingLeft + horizontalShift,
+                                              mBasePaddingTop + verticalShift,
+                                              mBasePaddingRight + horizontalShift,
+                                              mBasePaddingBottom - verticalShift);
+        invalidate();
+    }
+
     @Override
     public void onFinishInflate() {
         mBattery = findViewById(R.id.battery);
         mCutoutSpace = findViewById(R.id.cutout_space_view);
         mCenterIconSpace = findViewById(R.id.centered_icon_area);
+
+        mStatusBarContents = (ViewGroup) findViewById(R.id.status_bar_contents);
+
+        mBasePaddingLeft = mStatusBarContents.getPaddingStart();
+        mBasePaddingTop = mStatusBarContents.getPaddingTop();
+        mBasePaddingRight = mStatusBarContents.getPaddingEnd();
+        mBasePaddingBottom = mStatusBarContents.getPaddingBottom();
 
         updateResources();
     }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
@@ -242,6 +242,7 @@ import com.android.systemui.statusbar.phone.dagger.StatusBarComponent;
 import com.android.systemui.statusbar.phone.dagger.StatusBarPhoneModule;
 import com.android.systemui.statusbar.policy.BatteryController;
 import com.android.systemui.statusbar.policy.BrightnessMirrorController;
+import com.android.systemui.statusbar.policy.BurnInProtectionController;
 import com.android.systemui.statusbar.policy.ConfigurationController;
 import com.android.systemui.statusbar.policy.ConfigurationController.ConfigurationListener;
 import com.android.systemui.statusbar.policy.DeviceProvisionedController;
@@ -440,6 +441,7 @@ public class StatusBar extends SystemUI implements DemoMode,
     private final AutoHideController mAutoHideController;
     @Nullable
     private final KeyguardLiftController mKeyguardLiftController;
+    private BurnInProtectionController mBurnInProtectionController;
 
     private final Point mCurrentDisplaySize = new Point();
 
@@ -1318,6 +1320,8 @@ public class StatusBar extends SystemUI implements DemoMode,
                             mStatusBarView.findViewById(R.id.notification_lights_out));
                     mNotificationShadeWindowViewController.setStatusBarView(mStatusBarView);
                     checkBarModes();
+                    mBurnInProtectionController =
+                        new BurnInProtectionController(mContext, this, mStatusBarView);
                     handleCutout();
                     mStatusBarContent = (LinearLayout) mStatusBarView.findViewById(R.id.status_bar_contents);
                     mCenterArea = mStatusBarView.findViewById(R.id.centered_area);
@@ -4448,6 +4452,10 @@ public class StatusBar extends SystemUI implements DemoMode,
 
             updateNotificationPanelTouchState();
             mNotificationShadeWindowViewController.cancelCurrentTouch();
+
+            if (mBurnInProtectionController != null) {
+                mBurnInProtectionController.stopSwiftTimer();
+            }
             if (mLaunchCameraOnFinishedGoingToSleep) {
                 mLaunchCameraOnFinishedGoingToSleep = false;
 
@@ -4503,6 +4511,9 @@ public class StatusBar extends SystemUI implements DemoMode,
                 mLaunchCameraWhenFinishedWaking = false;
             }
             updateScrimController();
+            if (mBurnInProtectionController != null) {
+                mBurnInProtectionController.startSwiftTimer();
+            }
         }
     };
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/BurnInProtectionController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/BurnInProtectionController.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017-2018 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.statusbar.policy;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import android.view.View;
+
+import com.android.systemui.R;
+import com.android.systemui.statusbar.phone.PhoneStatusBarView;
+import com.android.systemui.statusbar.phone.NavigationBarView;
+import com.android.systemui.statusbar.phone.StatusBar;
+
+import java.util.Timer;
+import java.util.TimerTask;
+
+public class BurnInProtectionController {
+
+    private static final String TAG = BurnInProtectionController.class.getSimpleName();
+    private static final boolean DEBUG = false;
+
+    private boolean mSwiftEnabled;
+    private int mHorizontalShift = 0;
+    private int mVerticalShift = 0;
+    private int mHorizontalDirection = 1;
+    private int mVerticalDirection = 1;
+    private int mNavigationBarHorizontalMaxShift;
+    private int mNavigationBarVerticalMaxShift;
+    private int mHorizontalMaxShift;
+    private int mVerticalMaxShift;
+    private long mShiftInterval;
+
+    private Timer mTimer;
+
+    private StatusBar mStatusBar;
+    private PhoneStatusBarView mPhoneStatusBarView;
+
+    private Context mContext;
+
+    public BurnInProtectionController(Context context, StatusBar statusBar,
+                                      PhoneStatusBarView phoneStatusBarView) {
+        mContext = context;
+
+        mStatusBar = statusBar;
+
+        mPhoneStatusBarView = phoneStatusBarView;
+
+        mSwiftEnabled = mContext.getResources().getBoolean(
+                R.bool.config_statusBarBurnInProtection);
+        mHorizontalMaxShift = mContext.getResources()
+                .getDimensionPixelSize(R.dimen.horizontal_max_swift);
+        // total of ((vertical_max_swift - 1) * 2) pixels can be moved
+        mVerticalMaxShift = mContext.getResources()
+                .getDimensionPixelSize(R.dimen.vertical_max_swift) - 1;
+        mShiftInterval = (long) mContext.getResources().getInteger(R.integer.config_shift_interval);
+    }
+
+    public void startSwiftTimer() {
+        if (!mSwiftEnabled) return;
+        if (mTimer == null) {
+            mTimer = new Timer();
+        }
+        mTimer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                final Handler mUiHandler = new Handler(Looper.getMainLooper());
+                mUiHandler.post(() -> {
+                    swiftItems();
+                });
+            }
+        }, 0, mShiftInterval * 1000);
+        if (DEBUG) Log.d(TAG, "Started swift timer");
+    }
+
+    public void stopSwiftTimer() {
+        if (!mSwiftEnabled) return;
+        mTimer.cancel();
+        mTimer.purge();
+        mTimer = null;
+        if (DEBUG) Log.d(TAG, "Canceled swift timer");
+    }
+
+    private void swiftItems() {
+        mHorizontalShift += mHorizontalDirection;
+        if ((mHorizontalShift >=  mHorizontalMaxShift) ||
+                (mHorizontalShift <= -mHorizontalMaxShift)) {
+            mHorizontalDirection *= -1;
+        }
+
+        mVerticalShift += mVerticalDirection;
+        if ((mVerticalShift >=  mVerticalMaxShift) ||
+                (mVerticalShift <= -mVerticalMaxShift)) {
+            mVerticalDirection *= -1;
+        }
+
+        mPhoneStatusBarView.swiftStatusBarItems(mHorizontalShift, mVerticalShift);
+        NavigationBarView mNavigationBarView = mStatusBar.getNavigationBarView();
+        if (mNavigationBarView != null) {
+            mNavigationBarView.swiftNavigationBarItems(mHorizontalShift, mVerticalShift);
+        }
+
+        if (DEBUG) Log.d(TAG, "Swifting items..");
+    }
+}


### PR DESCRIPTION
Devices with OLED display suffer from
status-bar's notification items and nagivation bar's software keys
causing permanent burn-ins when used long-term.

Moving all items in the area
both horizontally and vertically workarounds this problem.

This new feature can be enabled by setting
config_statusBarBurnInProtection to true.

The shifting interval can be configured with config_shift_interval.
The default shifting interval is 60 seconds.

Forward-ported to oreo-mr1.

Signed-off-by: DennySPB <dennyspb@gmail.com>
Change-Id: I8df1ebc8bc0f359fe5a6a1fe11aa6201237a7359
Signed-off-by: Jayant-Deshmukh <jayantdeshmuk008@gmail.com>
Signed-off-by: Sipun Ku Mahanta <sipunkumar85@gmail.com>
Signed-off-by: SahilSonar <sss.sonar2003@gmail.com>