### PR TITLE
zygote: Enable USAP by default for S.

### DIFF
--- a/core/java/android/os/ZygoteProcess.java
+++ b/core/java/android/os/ZygoteProcess.java
@@ -86,7 +86,7 @@ public class ZygoteProcess {
      * not be used if the devices has a DeviceConfig profile pushed to it that contains a value for
      * this key.
      */
-    private static final String USAP_POOL_ENABLED_DEFAULT = "false";
+    private static final String USAP_POOL_ENABLED_DEFAULT = "true";
 
     /**
      * The name of the socket used to communicate with the primary zygote.


### PR DESCRIPTION
 * Issues that persisted with nativeZygoteJitEnabled
   in R have now been fixed.

Change-Id: I2571fbd12102ae2482bb3a0ca9e83711e4afb47c