### PR TITLE
fwb: DataSwitchTile: Fixed the logic of displaying the operator of the SIM card

### DIFF
--- a/packages/SystemUI/res/values/cr_strings.xml
+++ b/packages/SystemUI/res/values/cr_strings.xml
@@ -112,6 +112,7 @@
     <string name="qs_data_switch_label">Switch data card</string>
     <string name="qs_data_switch_changed_1">Using SIM 1 for Mobile data</string>
     <string name="qs_data_switch_changed_2">Using SIM 2 for Mobile data</string>
+    <string name="qs_data_switch_not_available">Not available</string>
 
     <!-- Label for UI element which allows deleting the screenshot [CHAR LIMIT=30] -->
     <string name="screenshot_delete_label">Delete</string>

--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/DataSwitchTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/DataSwitchTile.java
@@ -253,15 +253,18 @@ public class DataSwitchTile extends QSTileImpl<BooleanState> {
         if (subInfoList != null) {
             for (SubscriptionInfo subInfo : subInfoList) {
                 telephonyManager =
-                    mTelephonyManager.createForSubscriptionId(subInfo.getSubscriptionId());
+                        mTelephonyManager.createForSubscriptionId(subInfo.getSubscriptionId());
                 dataEnabled = telephonyManager.getDataEnabled();
-                if (!subInfo.isOpportunistic() || !dataEnabled) {
-                    telephonyManager.setDataEnabled(!dataEnabled && !foundActive);
-                    // Indicate we found sim with active data, disable data on remaining sim.
-                    if (!foundActive) foundActive = !dataEnabled;
+                if (!subInfo.isOpportunistic()) {
+                    if (dataEnabled) {
+                        // Store carrier label of inactive/opposite sim slot.
+                        mInactiveSlotName = subInfo.getDisplayName().toString();
+                    } else {
+                        telephonyManager.setDataEnabled(!dataEnabled && !foundActive);
+                        // Indicate we found sim with active data, disable data on remaining sim.
+                        if (!foundActive) foundActive = !dataEnabled;
+                    }
                 }
-                // Store carrier label of inactive/opposite sim slot.
-                if (!foundActive) mInactiveSlotName = subInfo.getDisplayName().toString();
                 Log.d(TAG, "Changed subID " + subInfo.getSubscriptionId() + " to "
                     + !dataEnabled);
             }


### PR DESCRIPTION
 After switching, the operator name was displayed as
 SIM1 operator name, regardless of further selection.
 Always - SIM1.

 This patch fixes that.

Change-Id: I7e31cb70373e0484afbfe907c45a0b6ca5802cb1