### PR TITLE
GLSurfaceView: Be less picky about EGLConfig alpha sizes

### DIFF
--- a/data/etc/privapp-permissions-platform.xml
+++ b/data/etc/privapp-permissions-platform.xml
@@ -262,6 +262,7 @@ applications that come with the platform
         <permission name="android.permission.INTERACT_ACROSS_USERS"/>
         <permission name="android.permission.MODIFY_PHONE_STATE"/>
         <permission name="android.permission.USE_RESERVED_DISK"/>
+        <permission name="android.permission.WRITE_APN_SETTINGS"/>
         <!-- Permissions required for reading and logging compat changes -->
         <permission name="android.permission.LOG_COMPAT_CHANGE" />
         <permission name="android.permission.READ_COMPAT_CHANGE_CONFIG" />

--- a/opengl/java/android/opengl/GLSurfaceView.java
+++ b/opengl/java/android/opengl/GLSurfaceView.java
@@ -970,7 +970,7 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
                     int a = findConfigAttrib(egl, display, config,
                             EGL10.EGL_ALPHA_SIZE, 0);
                     if ((r == mRedSize) && (g == mGreenSize)
-                            && (b == mBlueSize) && (a == mAlphaSize)) {
+                            && (b == mBlueSize) && (a >= mAlphaSize)) {
                         return config;
                     }
                 }

--- a/packages/SystemUI/res-keyguard/layout/keyguard_pin_view.xml
+++ b/packages/SystemUI/res-keyguard/layout/keyguard_pin_view.xml
@@ -162,7 +162,9 @@
                 >
             <com.android.keyguard.NumPadButton
                     android:id="@+id/delete_button"
+                    android:visibility="invisible"
                     android:layout_width="@dimen/num_pad_key_width"
+                    android:translationX="@dimen/num_pad_key_width"
                     android:layout_height="match_parent"
                     android:layout_marginEnd="@dimen/num_pad_key_margin_end"
                     android:contentDescription="@string/keyboardview_keycode_delete"
@@ -178,7 +180,9 @@
                     />
             <com.android.keyguard.NumPadButton
                     android:id="@+id/key_enter"
+                    android:visibility="invisible"
                     android:layout_width="@dimen/num_pad_key_width"
+                    android:translationX="@dimen/neg_num_pad_key_width"
                     android:layout_height="match_parent"
                     style="@style/NumPadKey.Enter"
                     android:contentDescription="@string/keyboardview_keycode_enter"

--- a/packages/SystemUI/res-keyguard/values/dimens.xml
+++ b/packages/SystemUI/res-keyguard/values/dimens.xml
@@ -89,6 +89,7 @@
 
     <!-- Spacing around each button used for PIN view -->
     <dimen name="num_pad_key_width">72dp</dimen>
+    <dimen name="neg_num_pad_key_width">-72dp</dimen>
     <dimen name="num_pad_entry_row_margin_bottom">16dp</dimen>
     <dimen name="num_pad_row_margin_bottom">6dp</dimen>
     <dimen name="num_pad_key_margin_end">12dp</dimen>

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardPinBasedInputView.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardPinBasedInputView.java
@@ -146,7 +146,6 @@ public abstract class KeyguardPinBasedInputView extends KeyguardAbsKeyInputView 
         mOkButton = findViewById(R.id.key_enter);
 
         mDeleteButton = findViewById(R.id.delete_button);
-        mDeleteButton.setVisibility(View.VISIBLE);
 
         mButtons[0] = findViewById(R.id.key0);
         mButtons[1] = findViewById(R.id.key1);

--- a/services/core/java/com/android/server/am/AppErrors.java
+++ b/services/core/java/com/android/server/am/AppErrors.java
@@ -1076,7 +1076,10 @@ class AppErrors {
             boolean showBackground = Settings.Secure.getIntForUser(mContext.getContentResolver(),
                     Settings.Secure.ANR_SHOW_BACKGROUND, 0,
                     mService.mUserController.getCurrentUserId()) != 0;
-            if (mService.mAtmInternal.canShowErrorDialogs() || showBackground) {
+            final boolean anrSilenced = mAppsNotReportingCrashes != null
+                    && mAppsNotReportingCrashes.contains(proc.info.packageName);
+            if (!anrSilenced &&
+                    (mService.mAtmInternal.canShowErrorDialogs() || showBackground)) {
                 AnrController anrController = errState.getDialogController().getAnrController();
                 if (anrController == null) {
                     errState.getDialogController().showAnrDialogs(data);
@@ -1101,7 +1104,7 @@ class AppErrors {
                 MetricsLogger.action(mContext, MetricsProto.MetricsEvent.ACTION_APP_ANR,
                         AppNotRespondingDialog.CANT_SHOW);
                 // Just kill the app if there is no dialog to be shown.
-                doKill = true;
+                doKill = !anrSilenced;
             }
         }
         if (doKill) {


### PR DESCRIPTION
EGLChooseConfig returns a "best match" set of visuals meeting or
exceeding the required r/g/b/a component depths.  But GLSurfaceView
oddly requires that the returned visual be an exact match.  Add to
that that the (rarely used outside of CTS) default request specifies
zero alpha bits and that not all drivers expose a zero-alpha
EGLConfig, and the default configuration will fail needlessly.

It's not incorrect to have alpha bits you didn't request: the only way
to produce divergent behavior is for a fragment shader to write out
explicit alpha values (into the channel it didn't want to begin with!)
with values other than 1.0 and then rely on them being ignored and
treated as 1.0.

For: AXIA-1448
Change-Id: I2f64995d7b9de1ae082aa47822af525390102083
Signed-off-by: Andy Ross <andy.ross@windriver.com>