### PR TITLE
StorageManagerService: Use non-binary XML

### DIFF
--- a/services/core/java/com/android/server/StorageManagerService.java
+++ b/services/core/java/com/android/server/StorageManagerService.java
@@ -172,6 +172,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.spec.KeySpec;
 import java.util.ArrayList;
@@ -2169,7 +2170,8 @@ class StorageManagerService extends IStorageManager.Stub
         try {
             fos = mSettingsFile.startWrite();
 
-            TypedXmlSerializer out = Xml.resolveSerializer(fos);
+            TypedXmlSerializer out = Xml.newFastSerializer();
+            out.setOutput(fos, StandardCharsets.UTF_8.name());
             out.startDocument(null, true);
             out.startTag(null, TAG_VOLUMES);
             out.attributeInt(null, ATTR_VERSION, VERSION_FIX_PRIMARY);


### PR DESCRIPTION
- Android 12 now writes XML files in binary format by default. This can cause incompatibility with TWRP which can hang when attempting to read XML files e.g. /data/system/storage.xml

Change-Id: I1c415ff0c403077fbd754dbbc72b761855ffdfde