### PR TITLE
data: Add ACCESS_SURFACE_FLINGER priv-app permission for launcher

### DIFF
--- a/data/etc/com.android.launcher3.xml
+++ b/data/etc/com.android.launcher3.xml
@@ -24,5 +24,6 @@
         <permission name="android.permission.START_TASKS_FROM_RECENTS"/>
         <permission name="android.permission.STATUS_BAR"/>
         <permission name="android.permission.STOP_APP_SWITCHES"/>
+        <permission name="android.permission.ACCESS_SURFACE_FLINGER"/>
     </privapp-permissions>
 </permissions>


### PR DESCRIPTION
Logcat:
E SurfaceFlinger: Only WindowManager is
allowed to use eEarlyWakeup[Start|End] flags

Ref: https://github.com/VoltageOS/packages_apps_Launcher3/commit/c36ecf23374f81f1d7fab5bc2902905af686298f

Co-authored-by: tejasvp25 <tejasvp25@gmail.com>
