### PR TITLE
PixelPropsUtils: Spoof Google Play Store to Pixel

### DIFF
--- a/core/java/com/android/internal/util/crdroid/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/crdroid/PixelPropsUtils.java
@@ -65,6 +65,7 @@ public class PixelPropsUtils {
 
     private static final String[] extraPackagesToChange = {
             "com.android.chrome",
+            "com.android.vending",
             "com.breel.wallpapers20"
     };
 


### PR DESCRIPTION
Fixes the issue in some devices where some apps like Google Chrome aren't compatible or cannot be updated (if prebuilt).
Thanks to @EndCredits for the suggestion.
Signed-off-by: masemoel <az.az.az.mjme@gmail.com>