### PR TITLE
Update qs_footer_actions_background.xml

### DIFF
--- a/packages/SystemUI/res/drawable/qs_footer_actions_background.xml
+++ b/packages/SystemUI/res/drawable/qs_footer_actions_background.xml
@@ -17,6 +17,8 @@
     <shape>
         <solid android:color="@color/footer_actions_bg"/>
         <corners android:topLeftRadius="@dimen/qs_corner_radius"
-                 android:topRightRadius="@dimen/qs_corner_radius"/>
+                 android:topRightRadius="@dimen/qs_corner_radius"
+                 android:bottomLeftRadius="@dimen/qs_corner_radius"
+                 android:bottomRightRadius="@dimen/qs_corner_radius"/>
     </shape>
 </inset>


### PR DESCRIPTION
Current top left and top right of the QS footer are rounded, while bottom left and bottom right are not. This commit makes all corners rounded, thus improving visual appearance of the QS footer
Before:
![199098733-7363b47d-bf2b-464f-ac33-b0be28ef4751](https://user-images.githubusercontent.com/628212/201447348-661ef93a-76ee-4f58-bb2b-149d418ffb54.jpg)
After:
![Screenshot_20221112-011014_crDroid Home](https://user-images.githubusercontent.com/628212/201447394-4b97d332-a633-4f58-b8b6-41b559d81832.png)
