### PR TITLE
base: Android P system animation (1/2)

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -17375,6 +17375,13 @@ public final class Settings {
          * @hide
          */
         public static final String RESTRICTED_NETWORKING_MODE = "restricted_networking_mode";
+
+        /**
+         * Android P animation style
+         * @hide
+         */
+        @Readable
+        public static final String PIE_ANIMATION_STYLE = "pie_animation_style";
     }
 
     /**

--- a/core/java/android/view/animation/AnimationUtils.java
+++ b/core/java/android/view/animation/AnimationUtils.java
@@ -26,8 +26,10 @@ import android.content.res.Resources.NotFoundException;
 import android.content.res.Resources.Theme;
 import android.content.res.XmlResourceParser;
 import android.os.SystemClock;
+import android.provider.Settings;
 import android.util.AttributeSet;
 import android.util.Xml;
+import android.util.PathParser;
 
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
@@ -133,6 +135,84 @@ public class AnimationUtils {
     public static Animation loadAnimation(Context context, @AnimRes int id)
             throws NotFoundException {
 
+        if (Settings.Global.getInt(context.getContentResolver(), Settings.Global.PIE_ANIMATION_STYLE, 0) != 0) {
+            switch(context.getResources().getResourceEntryName(id)) {
+                case "activity_open_enter" : return getActivityOpenEnterAnim();
+                case "activity_open_exit" : return getActivityOpenExitAnim();
+                case "activity_close_enter" : return getActivityCloseEnterAnim();
+                case "activity_close_exit" : return getActivityCloseExitAnim();
+            }
+        }
+        return loadAnimationFromXml(context, id);
+    }
+
+    private static Animation getActivityOpenEnterAnim() {
+        AnimationSet animationSet = new AnimationSet(false);
+        animationSet.setZAdjustment(Animation.ZORDER_TOP);
+        TranslateAnimation translateAnimation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.04100001f, Animation.RELATIVE_TO_SELF, 0.0f);
+        translateAnimation.setInterpolator(fastOutSlowIn());
+        translateAnimation.setDuration(425L);
+        animationSet.addAnimation(translateAnimation);
+        ClipRectAnimation clipRectAnimation = new ClipRectAnimation(0.0f, 0.959f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f);
+        clipRectAnimation.setDuration(425L);
+        clipRectAnimation.setInterpolator(fastOutExtraSlowIn());
+        animationSet.addAnimation(clipRectAnimation);
+        return animationSet;
+    }
+
+    private static Animation getActivityOpenExitAnim(){
+        AnimationSet animationSet = new AnimationSet(false);
+        TranslateAnimation translateAnimation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, -0.019999981f);
+        translateAnimation.setDuration(425L);
+        translateAnimation.setInterpolator(fastOutSlowIn());
+        animationSet.addAnimation(translateAnimation);
+        AlphaAnimation alphaAnimation = new AlphaAnimation(1.0f,0.9f);
+        alphaAnimation.setDuration(117L);
+        alphaAnimation.setInterpolator(new LinearInterpolator());
+        animationSet.addAnimation(alphaAnimation);
+        return animationSet;
+    }
+
+    private static Animation getActivityCloseEnterAnim(){
+        AnimationSet animationSet = new AnimationSet(false);
+        TranslateAnimation translateAnimation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, -0.019999981f, Animation.RELATIVE_TO_SELF, 0.0f);
+        translateAnimation.setDuration(425L);
+        translateAnimation.setInterpolator(fastOutSlowIn());
+        animationSet.addAnimation(translateAnimation);
+        AlphaAnimation alphaAnimation = new AlphaAnimation(0.9f,1.0f);
+        alphaAnimation.setDuration(425L);
+        alphaAnimation.setStartOffset(0);
+        alphaAnimation.setInterpolator(activityCloseDim());
+        animationSet.addAnimation(alphaAnimation);
+        return animationSet;
+    }
+
+    private static Animation getActivityCloseExitAnim(){
+        AnimationSet animationSet = new AnimationSet(false);
+        TranslateAnimation translateAnimation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.04100001f);
+        translateAnimation.setDuration(425L);
+        translateAnimation.setInterpolator(fastOutSlowIn());
+        animationSet.addAnimation(translateAnimation);
+        ClipRectAnimation clipRectAnimation = new ClipRectAnimation(0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.959f, 1.0f, 1.0f);
+        clipRectAnimation.setDuration(425L);
+        clipRectAnimation.setInterpolator(fastOutExtraSlowIn());
+        animationSet.addAnimation(clipRectAnimation);
+        return animationSet;
+    }
+
+    private static Interpolator fastOutSlowIn() {
+        return new PathInterpolator(0.4F, 0.0F, 0.2F, 1.0F);
+    }
+
+    private static Interpolator activityCloseDim() {
+        return new PathInterpolator(0.33f, 0.0f, 1.0f, 1.0f);
+    }
+
+    private static Interpolator fastOutExtraSlowIn() {
+        return new PathInterpolator(PathParser.createPathFromPathData("M 0,0 C 0.05, 0, 0.133333, 0.06, 0.166666, 0.4 C 0.208333, 0.82, 0.25, 1, 1, 1"));
+    }
+
+    private static Animation loadAnimationFromXml(Context context, int id) {
         XmlResourceParser parser = null;
         try {
             parser = context.getResources().getAnimation(id);

--- a/core/java/android/view/animation/ClipRectAnimation.java
+++ b/core/java/android/view/animation/ClipRectAnimation.java
@@ -138,6 +138,29 @@ public class ClipRectAnimation extends Animation {
         this(new Rect(fromL, fromT, fromR, fromB), new Rect(toL, toT, toR, toB));
     }
 
+    public ClipRectAnimation(float fromL, float fromT, float fromR, float fromB,
+            float toL, float toT, float toR, float toB) {
+        mFromLeftType = RELATIVE_TO_SELF;
+        mFromTopType = RELATIVE_TO_SELF;
+        mFromRightType = RELATIVE_TO_SELF;
+        mFromBottomType = RELATIVE_TO_SELF;
+
+        mToLeftType = RELATIVE_TO_SELF;
+        mToTopType = RELATIVE_TO_SELF;
+        mToRightType = RELATIVE_TO_SELF;
+        mToBottomType = RELATIVE_TO_SELF;
+
+        mFromLeftValue = fromL;
+        mFromTopValue = fromT;
+        mFromRightValue= fromR;
+        mFromBottomValue = fromB;
+
+        mToLeftValue = toL;
+        mToTopValue = toT;
+        mToRightValue= toR;
+        mToBottomValue = toB;
+    }
+
     @Override
     protected void applyTransformation(float it, Transformation tr) {
         int l = mFromRect.left + (int) ((mToRect.left - mFromRect.left) * it);


### PR DESCRIPTION
This commit is cherry-picked from the 8.1.x branch of AospExtended. The original author is @zeromod. [Original commit](https://github.com/AospExtended/platform_frameworks_base/commit/ea105254ceae19a621b7f487acbc4019b591fc4d).

[Preview](https://t.me/pzqqt_c/4624)

It's beautiful, compared to Android 12.1's default fade animation.

~~In the original commit, it directly modified the `core/java/android/view/animation/ClipRectAnimation.java` file. But this causes weird animations for some apps. Therefore, we add a new `core/java/android/view/animation/ClipRectAnimationF.java` file, which is only used by pie animations.~~

I tested it in my own unofficial build and found no issues. It should work on Android 13 as well.

Another commit is adding a switch in crDroidSettings. https://github.com/Pzqqt/android_packages_apps_crDroidSettings/commit/9a0bb9504a399cc91cdf30b72af4dd55baf48e77

Also remove hooks for task_open_enter, task_open_exit, task_close_enter, task_close_exit animations as they don't change much.