### PR TITLE
ScreenRecord: Disable HEVC codec by default

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/screenrecord/RecordingService.java
+++ b/packages/SystemUI/src/com/android/systemui/screenrecord/RecordingService.java
@@ -181,7 +181,7 @@ public class RecordingService extends Service implements ScreenMediaRecorderList
                 mShowStopDot = intent.getBooleanExtra(EXTRA_SHOW_STOP_DOT, false);
                 mLowQuality = intent.getBooleanExtra(EXTRA_LOW_QUALITY, false);
                 mLongerDuration = intent.getBooleanExtra(EXTRA_LONGER_DURATION, false);
-                mHEVC = intent.getBooleanExtra(EXTRA_HEVC, true);
+                mHEVC = intent.getBooleanExtra(EXTRA_HEVC, false);
 
                 MediaProjectionCaptureTarget captureTarget =
                         intent.getParcelableExtra(EXTRA_CAPTURE_TARGET,

--- a/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenRecordDialog.java
+++ b/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenRecordDialog.java
@@ -188,7 +188,7 @@ public class ScreenRecordDialog extends SystemUIDialog {
         mAudioSwitch.setChecked(Prefs.getInt(mUserContext, PREFS + PREF_AUDIO, 0) == 1);
         mOptions.setSelection(Prefs.getInt(mUserContext, PREFS + PREF_AUDIO_SOURCE, 0));
         mSkipSwitch.setChecked(Prefs.getInt(mUserContext, PREFS + PREF_SKIP, 0) == 1);
-        mHEVCSwitch.setChecked(Prefs.getInt(mUserContext, PREFS + PREF_HEVC, 1) == 1);
+        mHEVCSwitch.setChecked(Prefs.getInt(mUserContext, PREFS + PREF_HEVC, 0) == 1);
     }
 
     /**


### PR DESCRIPTION
Doesn't work at all on low-end devices. Let's keep it disabled by default to avoid confusing the user, when they discover that screen recorder failed to start without a reason.

Signed-off-by: iusmac <iusico.maxim@libero.it>