### PR TITLE
base: make per-app work with multi audio focus

### DIFF
--- a/services/core/java/com/android/server/audio/MediaFocusControl.java
+++ b/services/core/java/com/android/server/audio/MediaFocusControl.java
@@ -21,6 +21,7 @@ import android.annotation.Nullable;
 import android.app.AppOpsManager;
 import android.content.ContentResolver;
 import android.content.Context;
+import android.database.ContentObserver;
 import android.media.AudioAttributes;
 import android.media.AudioFocusInfo;
 import android.media.AudioManager;
@@ -101,13 +102,15 @@ public class MediaFocusControl implements PlayerFocusEnforcer {
     @GuardedBy("mExtFocusChangeLock")
     private long mExtFocusChangeCounter;
 
+    // Observer to work with per-app volume
+    private SettingsObserver mSettingsObserver;
+
     protected MediaFocusControl(Context cntxt, PlayerFocusEnforcer pfe) {
         mContext = cntxt;
         mAppOps = (AppOpsManager)mContext.getSystemService(Context.APP_OPS_SERVICE);
         mFocusEnforcer = pfe;
         final ContentResolver cr = mContext.getContentResolver();
-        mMultiAudioFocusEnabled = Settings.System.getIntForUser(cr,
-                Settings.System.MULTI_AUDIO_FOCUS_ENABLED, 0, cr.getUserId()) != 0;
+        mSettingsObserver = new SettingsObserver();
         initFocusThreading();
     }
 
@@ -1353,6 +1356,25 @@ public class MediaFocusControl implements PlayerFocusEnforcer {
         @Override
         public int hashCode() {
             return mUid;
+        }
+    }
+
+    private class SettingsObserver extends ContentObserver {
+
+        SettingsObserver() {
+            super(new Handler());
+            ContentResolver cr = mContext.getContentResolver();
+            cr.registerContentObserver(Settings.System.getUriFor(
+                Settings.System.SHOW_APP_VOLUME), true, this);
+        }
+
+        @Override
+        public void onChange(boolean selfChange) {
+            super.onChange(selfChange);
+            ContentResolver cr = mContext.getContentResolver();
+            mMultiAudioFocusEnabled = Settings.System.getIntForUser(cr,
+                    Settings.System.SHOW_APP_VOLUME, 1, cr.getUserId()) != 0;
+            updateMultiAudioFocus(mMultiAudioFocusEnabled);
         }
     }
 }


### PR DESCRIPTION
Seems like Google merged this for OEMs to make their own take on multi-audio focus, so we'll do an oem approach to make it work with per-app volume. This will allow the adjustment of various app volumes at the same time instead of leaving it to just enable the volume for just one app :)

Change-Id: I30966f6b95bdb03f139a9b2d1b7b30dbebb7a357