### PR TITLE
13.0 - Navigation Pill thickness customization [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -6308,6 +6308,12 @@ public final class Settings {
         public static final String KEYGUARD_QUICK_TOGGLES = "keyguard_quick_toggles";
 
         /**
+         * Size of gesture bar radius.
+         * @hide
+         */
+        public static final String GESTURE_NAVBAR_RADIUS = "gesture_navbar_radius";
+
+        /**
          * Keys we no longer back up under the current schema, but want to continue to
          * process when restoring historical backup datasets.
          *

--- a/packages/SystemUI/res/values/dimens.xml
+++ b/packages/SystemUI/res/values/dimens.xml
@@ -31,6 +31,9 @@
 
     <!-- dimensions for the navigation bar handle -->
     <dimen name="navigation_handle_radius">2dp</dimen>
+    <dimen name="navigation_handle_radius2">2.5dp</dimen>
+    <dimen name="navigation_handle_radius3">3dp</dimen>
+    <dimen name="navigation_handle_radius4">3.5dp</dimen>
     <dimen name="navigation_handle_bottom">10dp</dimen>
     <dimen name="navigation_handle_sample_horizontal_margin">10dp</dimen>
     <dimen name="navigation_home_handle_width">108dp</dimen>

--- a/packages/SystemUI/res/values/dimens.xml
+++ b/packages/SystemUI/res/values/dimens.xml
@@ -31,9 +31,11 @@
 
     <!-- dimensions for the navigation bar handle -->
     <dimen name="navigation_handle_radius">2dp</dimen>
-    <dimen name="navigation_handle_radius2">2.5dp</dimen>
-    <dimen name="navigation_handle_radius3">3dp</dimen>
-    <dimen name="navigation_handle_radius4">3.5dp</dimen>
+    <dimen name="navigation_handle_radius0">0.5dp</dimen>
+    <dimen name="navigation_handle_radius1">1dp</dimen>
+    <dimen name="navigation_handle_radius2">1.5dp</dimen>
+    <dimen name="navigation_handle_radius3">2.5dp</dimen>
+    <dimen name="navigation_handle_radius4">3dp</dimen>
     <dimen name="navigation_handle_bottom">10dp</dimen>
     <dimen name="navigation_handle_sample_horizontal_margin">10dp</dimen>
     <dimen name="navigation_home_handle_width">108dp</dimen>

--- a/packages/SystemUI/src/com/android/systemui/navigationbar/gestural/NavigationHandle.java
+++ b/packages/SystemUI/src/com/android/systemui/navigationbar/gestural/NavigationHandle.java
@@ -23,6 +23,7 @@ import android.content.res.Resources;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
+import android.provider.Settings;
 import android.util.AttributeSet;
 import android.view.ContextThemeWrapper;
 import android.view.View;
@@ -33,10 +34,11 @@ import com.android.systemui.navigationbar.buttons.ButtonInterface;
 
 public class NavigationHandle extends View implements ButtonInterface {
 
+    private final Context mContext;
     protected final Paint mPaint = new Paint();
     private @ColorInt final int mLightColor;
     private @ColorInt final int mDarkColor;
-    protected final float mRadius;
+    protected float mRadius;
     protected final float mBottom;
     private boolean mRequiresInvalidate;
 
@@ -46,8 +48,8 @@ public class NavigationHandle extends View implements ButtonInterface {
 
     public NavigationHandle(Context context, AttributeSet attr) {
         super(context, attr);
+        mContext = context;
         final Resources res = context.getResources();
-        mRadius = res.getDimension(R.dimen.navigation_handle_radius);
         mBottom = res.getDimension(R.dimen.navigation_handle_bottom);
 
         final int dualToneDarkTheme = Utils.getThemeAttr(context, R.attr.darkIconTheme);
@@ -75,8 +77,23 @@ public class NavigationHandle extends View implements ButtonInterface {
 
         // Draw that bar
         int navHeight = getHeight();
-        float height = mRadius * 2;
         int width = getWidth();
+        int radiusType = Settings.System.getInt(mContext.getContentResolver(),
+            Settings.System.GESTURE_NAVBAR_RADIUS, 0);
+        final Resources res = mContext.getResources();
+        switch (radiusType) {
+            case 0:
+                mRadius = res.getDimensionPixelSize(R.dimen.navigation_handle_radius);
+                break;
+            case 1:
+                mRadius = res.getDimensionPixelSize(R.dimen.navigation_handle_radius2);
+                break;
+            case 2:
+                mRadius = res.getDimensionPixelSize(R.dimen.navigation_handle_radius3);
+            case 3:
+                mRadius = res.getDimensionPixelSize(R.dimen.navigation_handle_radius4);
+        }
+        float height = mRadius * 2;
         float y = (navHeight - mBottom - height);
         canvas.drawRoundRect(0, y, width, y + height, mRadius, mRadius, mPaint);
     }

--- a/packages/SystemUI/src/com/android/systemui/navigationbar/gestural/NavigationHandle.java
+++ b/packages/SystemUI/src/com/android/systemui/navigationbar/gestural/NavigationHandle.java
@@ -83,15 +83,23 @@ public class NavigationHandle extends View implements ButtonInterface {
         final Resources res = mContext.getResources();
         switch (radiusType) {
             case 0:
-                mRadius = res.getDimensionPixelSize(R.dimen.navigation_handle_radius);
+                mRadius = res.getDimensionPixelSize(R.dimen.navigation_handle_radius0);
                 break;
             case 1:
-                mRadius = res.getDimensionPixelSize(R.dimen.navigation_handle_radius2);
+                mRadius = res.getDimensionPixelSize(R.dimen.navigation_handle_radius1);
                 break;
             case 2:
-                mRadius = res.getDimensionPixelSize(R.dimen.navigation_handle_radius3);
+                mRadius = res.getDimensionPixelSize(R.dimen.navigation_handle_radius2);
+                break;
             case 3:
+                mRadius = res.getDimensionPixelSize(R.dimen.navigation_handle_radius);
+                break;
+            case 4:
+                mRadius = res.getDimensionPixelSize(R.dimen.navigation_handle_radius3);
+                break;
+            case 5:
                 mRadius = res.getDimensionPixelSize(R.dimen.navigation_handle_radius4);
+                break;
         }
         float height = mRadius * 2;
         float y = (navHeight - mBottom - height);


### PR DESCRIPTION
While I was rooting around in Evolution-X in the Settings repo trying to fix the "Back" gesture at "Low" sensitivity, I found this one for yet another tweak to the navigation pill, allowing us to adjust the thickness (and corresponding radius of the roundrect that it's drawn with).
The first commit only allowed making it thicker, and frankly, I'd like for it to be burning in FEWER pixels, so I added those modifications in second commit.
Original: https://github.com/Evolution-X/frameworks_base/commit/672a2c3d34ef281ce857f515645ed680321dbbdb#diff-4db31cf990cdd3c22834a20f944b93d6de219eee493bc75a6dd17d98efe3772d

Tests:
Compiled, additional slider for "Pill radius" now in Settings > System > System Navigation > Gesture Navigation settings, works as expected.