### PR TITLE
SystemUI: Rework media art filter

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/MediaArtworkProcessor.kt
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/MediaArtworkProcessor.kt
@@ -18,6 +18,7 @@ package com.android.systemui.statusbar
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.graphics.Point
 import android.graphics.Rect
 import android.renderscript.Allocation
@@ -32,17 +33,18 @@ import com.android.systemui.statusbar.notification.MediaNotificationProcessor
 import javax.inject.Inject
 
 private const val TAG = "MediaArtworkProcessor"
-private const val COLOR_ALPHA = 255
-private const val BLUR_RADIUS = 1f
-private const val DOWNSAMPLE = 1
+private const val COLOR_ALPHA = (255 * 0.7f).toInt()
+private const val DOWNSAMPLE = 6
 
 @SysUISingleton
 class MediaArtworkProcessor @Inject constructor() {
 
     private val mTmpSize = Point()
     private var mArtworkCache: Bitmap? = null
+    private var mDownSample: Int = DOWNSAMPLE
+    //private var mColorAlpha: Int = COLOR_ALPHA
 
-    fun processArtwork(context: Context, artwork: Bitmap): Bitmap? {
+    fun processArtwork(context: Context, artwork: Bitmap, blur_radius: Float): Bitmap? {
         if (mArtworkCache != null) {
             return mArtworkCache
         }
@@ -52,10 +54,11 @@ class MediaArtworkProcessor @Inject constructor() {
         var output: Allocation? = null
         var inBitmap: Bitmap? = null
         try {
+            if (blur_radius < 5f) mDownSample = 2 else mDownSample = DOWNSAMPLE
             @Suppress("DEPRECATION")
             context.display?.getSize(mTmpSize)
             val rect = Rect(0, 0, artwork.width, artwork.height)
-            MathUtils.fitRect(rect, Math.max(mTmpSize.x / DOWNSAMPLE, mTmpSize.y / DOWNSAMPLE))
+            MathUtils.fitRect(rect, Math.max(mTmpSize.x / mDownSample, mTmpSize.y / mDownSample))
             inBitmap = Bitmap.createScaledBitmap(artwork, rect.width(), rect.height(),
                     true /* filter */)
             // Render script blurs only support ARGB_8888, we need a conversion if we got a
@@ -65,27 +68,36 @@ class MediaArtworkProcessor @Inject constructor() {
                 inBitmap = oldIn.copy(Bitmap.Config.ARGB_8888, false /* isMutable */)
                 oldIn.recycle()
             }
-            val outBitmap = Bitmap.createBitmap(inBitmap.width, inBitmap.height,
-                    Bitmap.Config.ARGB_8888)
+            var outBitmap: Bitmap?
+            if (blur_radius >= 1f) {
+                outBitmap = Bitmap.createBitmap(inBitmap.width, inBitmap.height,
+                        Bitmap.Config.ARGB_8888)
+                input = Allocation.createFromBitmap(renderScript, inBitmap,
+                        Allocation.MipmapControl.MIPMAP_NONE, Allocation.USAGE_GRAPHICS_TEXTURE)
+                output = Allocation.createFromBitmap(renderScript, outBitmap)
+                    blur.setRadius(blur_radius)
+                    blur.setInput(input)
+                    blur.forEach(output)
+                output.copyTo(outBitmap)
+            } else {
+                outBitmap = inBitmap.copy(Bitmap.Config.ARGB_8888, true/*mutable*/)
+            }
 
-            input = Allocation.createFromBitmap(renderScript, inBitmap,
-                    Allocation.MipmapControl.MIPMAP_NONE, Allocation.USAGE_GRAPHICS_TEXTURE)
-            output = Allocation.createFromBitmap(renderScript, outBitmap)
+            val swatch = MediaNotificationProcessor.findBackgroundSwatch(artwork)
 
-            blur.setRadius(BLUR_RADIUS)
-            blur.setInput(input)
-            blur.forEach(output)
-            output.copyTo(outBitmap)
-
+            val canvas = Canvas(outBitmap)
+            canvas.drawColor(ColorUtils.setAlphaComponent(swatch.rgb, COLOR_ALPHA/*mColorAlpha*/))
             return outBitmap
         } catch (ex: IllegalArgumentException) {
             Log.e(TAG, "error while processing artwork", ex)
             return null
         } finally {
-            input?.destroy()
-            output?.destroy()
-            blur.destroy()
+            if (blur_radius >= 1f) {
+                input?.destroy()
+                output?.destroy()
+            }
             inBitmap?.recycle()
+            blur.destroy()
         }
     }
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/NotificationMediaManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NotificationMediaManager.java
@@ -600,29 +600,7 @@ public class NotificationMediaManager implements Dumpable, TunerService.Tunable 
         // set media artwork as lockscreen wallpaper if player is playing
         if (bmp != null && (mShowMediaMetadata || !ENABLE_LOCKSCREEN_WALLPAPER) &&
                 PlaybackState.STATE_PLAYING == getMediaControllerPlaybackState(mMediaController)) {
-            switch (mAlbumArtFilter) {
-                case 0:
-                default:
-                    artworkDrawable = new BitmapDrawable(mBackdropBack.getResources(), bmp);
-                    break;
-                case 1:
-                    artworkDrawable = new BitmapDrawable(mBackdropBack.getResources(),
-                        ImageHelper.toGrayscale(bmp));
-                    break;
-                case 2:
-                    Drawable aw = new BitmapDrawable(mBackdropBack.getResources(), bmp);
-                    artworkDrawable = new BitmapDrawable(ImageHelper.getColoredBitmap(aw,
-                        mContext.getResources().getColor(R.color.accent_device_default_light)));
-                    break;
-                case 3:
-                    artworkDrawable = new BitmapDrawable(mBackdropBack.getResources(),
-                        ImageHelper.getBlurredImage(mContext, bmp, 7.0f));
-                    break;
-                case 4:
-                    artworkDrawable = new BitmapDrawable(mBackdropBack.getResources(),
-                        ImageHelper.getGrayscaleBlurredImage(mContext, bmp, 7.0f));
-                    break;
-            }
+            artworkDrawable = new BitmapDrawable(mBackdropBack.getResources(), bmp);
         }
         boolean hasMediaArtwork = artworkDrawable != null;
         boolean allowWhenShade = false;
@@ -784,7 +762,19 @@ public class NotificationMediaManager implements Dumpable, TunerService.Tunable 
     };
 
     private Bitmap processArtwork(Bitmap artwork) {
-        return mMediaArtworkProcessor.processArtwork(mContext, artwork);
+        switch (mAlbumArtFilter) {
+            case 0:
+            default:
+                return artwork;
+            case 1:
+                return Bitmap.createBitmap(ImageHelper.toGrayscale(artwork));
+            case 2:
+                return Bitmap.createBitmap(ImageHelper.getColoredBitmap(new BitmapDrawable(mBackdropBack.getResources(), artwork), mContext.getResources().getColor(R.color.accent_device_default_light)));
+            case 3:
+                return mMediaArtworkProcessor.processArtwork(mContext, artwork, 25f);
+            case 4:
+                return mMediaArtworkProcessor.processArtwork(mContext, Bitmap.createBitmap(ImageHelper.toGrayscale(artwork)), 25f);
+        }
     }
 
     @MainThread


### PR DESCRIPTION
Current implementation makes media art processed twice:
- In finishUpdateMediaMetaData by using ImageHelper
- In processArtwork by using MediaArtworkProcessor

We prefer processArtwork because it's in an AsyncTask. Let's extend capabilities of MediaArtworkProcessor and let processArtwork does the job.