### PR TITLE
SUPL: Don't send IMSI / Phone number to SUPL server

### DIFF
--- a/services/core/java/com/android/server/location/gnss/GnssLocationProvider.java
+++ b/services/core/java/com/android/server/location/gnss/GnssLocationProvider.java
@@ -1721,6 +1721,11 @@ public class GnssLocationProvider extends AbstractLocationProvider implements
         int type = AGPS_SETID_TYPE_NONE;
         String setId = null;
 
+        /*
+         * We don't want to tell Google our IMSI or phone number to spy on us!
+         * As devices w/o SIM card also have working GPS, providing this data does
+         * not seem to add a lot of value, at least not for the device holder
+         *
         int subId = SubscriptionManager.getDefaultDataSubscriptionId();
         if (mNIHandler.getInEmergency() && mNetworkConnectivityHandler.getActiveSubId() >= 0) {
             subId = mNetworkConnectivityHandler.getActiveSubId();
@@ -1740,7 +1745,7 @@ public class GnssLocationProvider extends AbstractLocationProvider implements
                 // This means the framework has the SIM card.
                 type = AGPS_SETID_TYPE_MSISDN;
             }
-        }
+        } */
 
         mGnssNative.setAgpsSetId(type, (setId == null) ? "" : setId);
     }


### PR DESCRIPTION
As [originally submitted](https://review.lineageos.org/c/LineageOS/android_frameworks_base/+/249219) in LineageOS but unfortunately abandoned, I'm re-introducing the change here, which is also included in [GrapheneOS](https://github.com/GrapheneOS/platform_frameworks_base/commit/5317437f9e9334683b3eafca96a95d0ed67f4020) and [DivestOS](https://github.com/Divested-Mobile/DivestOS-Build/commit/bb72bccbeb6efadaf2440c47bdd7b8d7e8838b6e#diff-d78bf1944f4c2c7fb00665205249c7874cdb729a28e51dc0a51b3b40b8101580). 