### PR TITLE
base: Fix smart charging bug

### DIFF
--- a/services/core/java/com/android/server/power/PowerManagerService.java
+++ b/services/core/java/com/android/server/power/PowerManagerService.java
@@ -143,6 +143,7 @@ import dalvik.annotation.optimization.NeverCompile;
 
 import lineageos.providers.LineageSettings;
 
+import java.io.File;
 import java.io.FileDescriptor;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -851,7 +852,6 @@ public final class PowerManagerService extends SystemService
     private boolean mSmartChargingAvailable;
     private boolean mSmartChargingEnabled;
     private boolean mSmartChargingResetStats;
-    private boolean mPowerInputSuspended = false;
     private int mSmartChargingLevel;
     private int mSmartChargingResumeLevel;
     private int mSmartChargingLevelDefaultConfig;
@@ -2719,18 +2719,25 @@ public final class PowerManagerService extends SystemService
 
     private void updateSmartChargingStatus() {
         if (!mSmartChargingAvailable) return;
-        if (mPowerInputSuspended && ((mSmartChargingResumeLevel < mSmartChargingLevel &&
+
+        String readValue = "";
+        try {
+            readValue= FileUtils.readTextFile(new File(mPowerInputSuspendSysfsNode), 100, "");
+        } catch (IOException e) {
+            Slog.e(TAG, "failed to write to " + mPowerInputSuspendSysfsNode);
+        }
+        
+        boolean powerInputSuspended = readValue.contains(mPowerInputSuspendValue)? true: false;
+        
+        if (powerInputSuspended && ((mSmartChargingResumeLevel < mSmartChargingLevel &&
             mBatteryLevel <= mSmartChargingResumeLevel) || !mSmartChargingEnabled)) {
             try {
                 FileUtils.stringToFile(mPowerInputSuspendSysfsNode, mPowerInputResumeValue);
-                mPowerInputSuspended = false;
             } catch (IOException e) {
                 Slog.e(TAG, "failed to write to " + mPowerInputSuspendSysfsNode);
             }
-            return;
         }
-
-        if (mSmartChargingEnabled && !mPowerInputSuspended && (mBatteryLevel >= mSmartChargingLevel)) {
+        else if (mSmartChargingEnabled && !powerInputSuspended && (mBatteryLevel >= mSmartChargingLevel)) {
             Slog.i(TAG, "Smart charging reset stats: " + mSmartChargingResetStats);
             if (mSmartChargingResetStats) {
                 try {
@@ -2742,7 +2749,6 @@ public final class PowerManagerService extends SystemService
 
             try {
                 FileUtils.stringToFile(mPowerInputSuspendSysfsNode, mPowerInputSuspendValue);
-                mPowerInputSuspended = true;
             } catch (IOException e) {
                     Slog.e(TAG, "failed to write to " + mPowerInputSuspendSysfsNode);
             }


### PR DESCRIPTION
The value of mPowerInputSuspended is switched to true or false in the code, neglecting the fact that it can also be changed by the sysfs node when the phone is plugged/unplugged.

If the user unplugs when the power is above charging limit, mPowerInputSuspended is still true. Therefore, if it's plugged in again, there will be no attempt to suspend input. The phone will continue to charge.

Fix by reading sysfs node for the actual value whenever updateSmartChargingStatus() is called.