### PR TITLE
LessBoring: fixup LessBoring preventing bubbles

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/notification/interruption/NotificationInterruptStateProviderImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/notification/interruption/NotificationInterruptStateProviderImpl.java
@@ -186,11 +186,6 @@ public class NotificationInterruptStateProviderImpl implements NotificationInter
             return false;
         }
 
-        if (!mReTicker && mLessBoringHeadsUp && shouldSkipHeadsUp(entry)) {
-            mLogger.logNoHeadsUpShouldSkipPackage(entry);
-            return false;
-        }
-
         if (!entry.canBubble()) {
             mLogger.logNoBubbleNotAllowed(entry);
             return false;
@@ -399,6 +394,11 @@ public class NotificationInterruptStateProviderImpl implements NotificationInter
     private boolean shouldHeadsUpWhenAwake(NotificationEntry entry, boolean log) {
         if (!mUseHeadsUp) {
             if (log) mLogger.logNoHeadsUpFeatureDisabled();
+            return false;
+        }
+
+        if (!mReTicker && mLessBoringHeadsUp && shouldSkipHeadsUp(entry)) {
+            mLogger.logNoHeadsUpShouldSkipPackage(entry);
             return false;
         }
 


### PR DESCRIPTION
The check to skip Heads Up was mistakenly added under `shouldBubbleUp()` instead of `shouldHeadsUpWhenAwake()`