### PR TITLE
[crDroid 7] Fix of video resolution on build-in "Screen Recording" 

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
+++ b/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
@@ -203,7 +203,7 @@ public class ScreenMediaRecorder {
      * @param refreshRate Desired refresh rate
      * @return array with supported width, height, and refresh rate
      */
-    private int[] getSupportedSize(int screenWidth, int screenHeight, int refreshRate) {
+    private int[] getSupportedSize(final int screenWidth, final int screenHeight, int refreshRate) {
         double maxScale = 0;
 
         MediaCodecList codecList = new MediaCodecList(MediaCodecList.REGULAR_CODECS);
@@ -223,25 +223,33 @@ public class ScreenMediaRecorder {
                     int width = vc.getSupportedWidths().getUpper();
                     int height = vc.getSupportedHeights().getUpper();
 
-                    if (width >= screenWidth && height >= screenHeight
-                            && vc.isSizeSupported(screenWidth, screenHeight)) {
+                    int screenWidthAligned = screenWidth;
+                    if (screenWidthAligned % vc.getWidthAlignment() != 0) {
+                        screenWidthAligned -= (screenWidthAligned % vc.getWidthAlignment());
+                    }
+                    int screenHeightAligned = screenHeight;
+                    if (screenHeightAligned % vc.getHeightAlignment() != 0) {
+                        screenHeightAligned -= (screenHeightAligned % vc.getHeightAlignment());
+                    }
 
+                    if (width >= screenWidthAligned && height >= screenHeightAligned
+                            && vc.isSizeSupported(screenWidthAligned, screenHeightAligned)) {
                         // Desired size is supported, now get the rate
-                        int maxRate = vc.getSupportedFrameRatesFor(screenWidth, screenHeight)
-                                .getUpper().intValue();
+                        int maxRate = vc.getSupportedFrameRatesFor(screenWidthAligned,
+                                screenHeightAligned).getUpper().intValue();
 
                         if (maxRate < refreshRate) {
                             refreshRate = maxRate;
                         }
                         Log.d(TAG, "Screen size supported at rate " + refreshRate);
-                        return new int[]{screenWidth, screenHeight, refreshRate};
+                        return new int[]{screenWidthAligned, screenHeightAligned, refreshRate};
                     }
 
                     // Otherwise, continue searching
                     double scale = Math.min(((double) width / screenWidth),
                             ((double) height / screenHeight));
                     if (scale > maxScale) {
-                        maxScale = scale;
+                        maxScale = Math.min(1, scale);
                         maxInfo = vc;
                     }
                 }

--- a/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
+++ b/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
@@ -293,12 +293,12 @@ public class ScreenMediaRecorder {
      */
     void end() {
         mMediaRecorder.stop();
-        mMediaProjection.stop();
         mMediaRecorder.release();
-        mMediaRecorder = null;
-        mMediaProjection = null;
         mInputSurface.release();
         mVirtualDisplay.release();
+        mMediaProjection.stop();
+        mMediaRecorder = null;
+        mMediaProjection = null;
         stopInternalAudioRecording();
 
         Log.d(TAG, "end recording");

--- a/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
+++ b/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
@@ -66,7 +66,8 @@ public class ScreenMediaRecorder {
     private static final int TOTAL_NUM_TRACKS = 1;
     private static final int VIDEO_FRAME_RATE = 30;
     private static final int VIDEO_FRAME_RATE_TO_RESOLUTION_RATIO = 6;
-    private static final int LOW_VIDEO_BIT_RATE = 3000000;
+    private static final int LOW_VIDEO_FRAME_RATE_TO_RESOLUTION_RATIO = 2;
+    private static final int LOW_FRAME_RATE = 25;
     private static final int AUDIO_BIT_RATE = 196000;
     private static final int AUDIO_SAMPLE_RATE = 44100;
     private static final int MAX_DURATION_MS = 60 * 60 * 1000;
@@ -138,15 +139,16 @@ public class ScreenMediaRecorder {
         DisplayMetrics metrics = new DisplayMetrics();
         WindowManager wm = (WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE);
         wm.getDefaultDisplay().getRealMetrics(metrics);
-        int refreshRate = mLowQuality? VIDEO_FRAME_RATE : (int) wm.getDefaultDisplay().getRefreshRate();
+        int refreshRate = mLowQuality ? LOW_FRAME_RATE
+                : (int) wm.getDefaultDisplay().getRefreshRate();
         if (mMaxRefreshRate != 0 && refreshRate > mMaxRefreshRate) refreshRate = mMaxRefreshRate;
         int[] dimens = getSupportedSize(metrics.widthPixels, metrics.heightPixels, refreshRate);
         int width = dimens[0];
         int height = dimens[1];
         refreshRate = dimens[2];
-        int vidBitRate = mLowQuality ? LOW_VIDEO_BIT_RATE :
-                width * height * refreshRate / VIDEO_FRAME_RATE
-                * VIDEO_FRAME_RATE_TO_RESOLUTION_RATIO;
+        int resRatio = mLowQuality ? LOW_VIDEO_FRAME_RATE_TO_RESOLUTION_RATIO
+                : VIDEO_FRAME_RATE_TO_RESOLUTION_RATIO;
+        int vidBitRate = width * height * refreshRate / VIDEO_FRAME_RATE * resRatio;
         /* PS: HEVC can be set too, to reduce file size without quality loss (h265 is more efficient than h264),
         but at the same time the cpu load is 8-10 times higher and some devices don't support it yet */
         mMediaRecorder.setVideoEncoder(MediaRecorder.VideoEncoder.H264);

--- a/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
+++ b/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
@@ -29,8 +29,8 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.hardware.display.DisplayManager;
 import android.hardware.display.VirtualDisplay;
+import android.media.MediaCodec;
 import android.media.MediaCodecInfo;
-import android.media.MediaCodecList;
 import android.media.MediaFormat;
 import android.media.MediaMuxer;
 import android.media.MediaRecorder;
@@ -203,77 +203,63 @@ public class ScreenMediaRecorder {
      * @param refreshRate Desired refresh rate
      * @return array with supported width, height, and refresh rate
      */
-    private int[] getSupportedSize(final int screenWidth, final int screenHeight, int refreshRate) {
-        double maxScale = 0;
+    private int[] getSupportedSize(final int screenWidth, final int screenHeight, int refreshRate)
+            throws IOException {
+        String videoType = MediaFormat.MIMETYPE_VIDEO_AVC;
 
-        MediaCodecList codecList = new MediaCodecList(MediaCodecList.REGULAR_CODECS);
-        MediaCodecInfo.VideoCapabilities maxInfo = null;
-        for (MediaCodecInfo codec : codecList.getCodecInfos()) {
-            String videoType = MediaFormat.MIMETYPE_VIDEO_AVC;
-            String[] types = codec.getSupportedTypes();
-            for (String t : types) {
-                if (!t.equalsIgnoreCase(videoType)) {
-                    continue;
-                }
-                MediaCodecInfo.CodecCapabilities capabilities =
-                        codec.getCapabilitiesForType(videoType);
-                if (capabilities != null && capabilities.getVideoCapabilities() != null) {
-                    MediaCodecInfo.VideoCapabilities vc = capabilities.getVideoCapabilities();
+        // Get max size from the decoder, to ensure recordings will be playable on device
+        MediaCodec decoder = MediaCodec.createDecoderByType(videoType);
+        MediaCodecInfo.VideoCapabilities vc = decoder.getCodecInfo()
+                .getCapabilitiesForType(videoType).getVideoCapabilities();
+        decoder.release();
 
-                    int width = vc.getSupportedWidths().getUpper();
-                    int height = vc.getSupportedHeights().getUpper();
+        // Check if we can support screen size as-is
+        int width = vc.getSupportedWidths().getUpper();
+        int height = vc.getSupportedHeights().getUpper();
 
-                    int screenWidthAligned = screenWidth;
-                    if (screenWidthAligned % vc.getWidthAlignment() != 0) {
-                        screenWidthAligned -= (screenWidthAligned % vc.getWidthAlignment());
-                    }
-                    int screenHeightAligned = screenHeight;
-                    if (screenHeightAligned % vc.getHeightAlignment() != 0) {
-                        screenHeightAligned -= (screenHeightAligned % vc.getHeightAlignment());
-                    }
+        int screenWidthAligned = screenWidth;
+        if (screenWidthAligned % vc.getWidthAlignment() != 0) {
+            screenWidthAligned -= (screenWidthAligned % vc.getWidthAlignment());
+        }
+        int screenHeightAligned = screenHeight;
+        if (screenHeightAligned % vc.getHeightAlignment() != 0) {
+            screenHeightAligned -= (screenHeightAligned % vc.getHeightAlignment());
+        }
 
-                    if (width >= screenWidthAligned && height >= screenHeightAligned
-                            && vc.isSizeSupported(screenWidthAligned, screenHeightAligned)) {
-                        // Desired size is supported, now get the rate
-                        int maxRate = vc.getSupportedFrameRatesFor(screenWidthAligned,
-                                screenHeightAligned).getUpper().intValue();
+        if (width >= screenWidthAligned && height >= screenHeightAligned
+                && vc.isSizeSupported(screenWidthAligned, screenHeightAligned)) {
+            // Desired size is supported, now get the rate
+            int maxRate = vc.getSupportedFrameRatesFor(screenWidthAligned,
+                    screenHeightAligned).getUpper().intValue();
 
-                        if (maxRate < refreshRate) {
-                            refreshRate = maxRate;
-                        }
-                        Log.d(TAG, "Screen size supported at rate " + refreshRate);
-                        return new int[]{screenWidthAligned, screenHeightAligned, refreshRate};
-                    }
-
-                    // Otherwise, continue searching
-                    double scale = Math.min(((double) width / screenWidth),
-                            ((double) height / screenHeight));
-                    if (scale > maxScale) {
-                        maxScale = Math.min(1, scale);
-                        maxInfo = vc;
-                    }
-                }
+            if (maxRate < refreshRate) {
+                refreshRate = maxRate;
             }
+            Log.d(TAG, "Screen size supported at rate " + refreshRate);
+            return new int[]{screenWidthAligned, screenHeightAligned, refreshRate};
         }
 
-        // Resize for max supported size
-        int scaledWidth = (int) (screenWidth * maxScale);
-        int scaledHeight = (int) (screenHeight * maxScale);
-        if (scaledWidth % maxInfo.getWidthAlignment() != 0) {
-            scaledWidth -= (scaledWidth % maxInfo.getWidthAlignment());
+        // Otherwise, resize for max supported size
+        double scale = Math.min(((double) width / screenWidth),
+                ((double) height / screenHeight));
+
+        int scaledWidth = (int) (screenWidth * scale);
+        int scaledHeight = (int) (screenHeight * scale);
+        if (scaledWidth % vc.getWidthAlignment() != 0) {
+            scaledWidth -= (scaledWidth % vc.getWidthAlignment());
         }
-        if (scaledHeight % maxInfo.getHeightAlignment() != 0) {
-            scaledHeight -= (scaledHeight % maxInfo.getHeightAlignment());
+        if (scaledHeight % vc.getHeightAlignment() != 0) {
+            scaledHeight -= (scaledHeight % vc.getHeightAlignment());
         }
 
         // Find max supported rate for size
-        int maxRate = maxInfo.getSupportedFrameRatesFor(scaledWidth, scaledHeight)
+        int maxRate = vc.getSupportedFrameRatesFor(scaledWidth, scaledHeight)
                 .getUpper().intValue();
         if (maxRate < refreshRate) {
             refreshRate = maxRate;
         }
 
-        Log.d(TAG, "Resized by " + maxScale + ": " + scaledWidth + ", " + scaledHeight
+        Log.d(TAG, "Resized by " + scale + ": " + scaledWidth + ", " + scaledHeight
                 + ", " + refreshRate);
         return new int[]{scaledWidth, scaledHeight, refreshRate};
     }


### PR DESCRIPTION
This patch needed for downscale video resolution when display have bigger resolution that CPU can encode with hardware acceleration.

For example: Redmi 9T has 2340x1080p display and Snapdragon 662 with 1920x1080p hardware encode acceleration.

All commits cherry-picked from 12.0/13.0.