### PR TITLE
 PixelPropsUtils: Add Gameprops for Battlegrounds Mobile India (BGMI)

### DIFF
--- a/core/java/com/android/internal/util/crdroid/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/crdroid/PixelPropsUtils.java
@@ -46,6 +46,7 @@ public class PixelPropsUtils {
     private static final Map<String, Object> propsToChangeOP9R;
     private static final Map<String, Object> propsToChange11T;
     private static final Map<String, Object> propsToChangeF4;
+    private static final Map<String, Object> propsToChangeK30U;
     private static final Map<String, ArrayList<String>> propsToKeep;
 
     // Packages to Spoof as Pixel 7 Pro
@@ -121,7 +122,6 @@ public class PixelPropsUtils {
     private static final String[] packagesToChangeOP8P = {
             "com.mobile.legends",
             "com.netease.lztgglobal",
-            "com.pubg.imobile",
             "com.pubg.krmobile",
             "com.rekoo.pubgm",
             "com.riotgames.league.wildrift",
@@ -151,6 +151,11 @@ public class PixelPropsUtils {
     private static final String[] packagesToChangeF4 = {
             "com.dts.freefiremax",
             "com.dts.freefireth"
+    };
+
+    // Packages to Spoof as Redmi K30 Ultra
+    private static final String[] packagesToChangeK30U = {
+            "com.pubg.imobile"
     };
 
     // Codenames for currently supported Pixels by Google
@@ -218,6 +223,9 @@ public class PixelPropsUtils {
         propsToChangeF4 = new HashMap<>();
         propsToChangeF4.put("MODEL", "22021211RG");
         propsToChangeF4.put("MANUFACTURER", "Xiaomi");
+        propsToChangeK30U = new HashMap<>();
+        propsToChangeK30U.put("MODEL", "M2006J10C");
+        propsToChangeK30U.put("MANUFACTURER", "Xiaomi");
     }
 
     public static void setProps(String packageName) {
@@ -322,6 +330,13 @@ public class PixelPropsUtils {
             } else if (Arrays.asList(packagesToChangeOP9R).contains(packageName)) {
                 if (DEBUG) Log.d(TAG, "Defining props for: " + packageName);
                 for (Map.Entry<String, Object> prop : propsToChangeOP9R.entrySet()) {
+                    String key = prop.getKey();
+                    Object value = prop.getValue();
+                    setPropValue(key, value);
+                }
+            } else if (Arrays.asList(packagesToChangeK30U).contains(packageName)) {
+                if (DEBUG) Log.d(TAG, "Defining props for: " + packageName);
+                for (Map.Entry<String, Object> prop : propsToChangeK30U.entrySet()) {
                     String key = prop.getKey();
                     Object value = prop.getValue();
                     setPropValue(key, value);


### PR DESCRIPTION
* Krafton disabled 90fps for android, so OP8P spoofing is no longer working
* Now spoofing bgmi with Redmi K30 Ultra, unlocks Smooth-Extreme to HDR-Extreme