### PR TITLE
Revert "EventLog: Disable event writing in production builds"

### DIFF
--- a/core/java/android/util/EventLog.java
+++ b/core/java/android/util/EventLog.java
@@ -334,13 +334,7 @@ public class EventLog {
      * @param value A value to log
      * @return The number of bytes written
      */
-    public static int writeEvent(int tag, int value) {
-        if (!Build.IS_DEBUGGABLE) {
-            return 0;
-        }
-
-        return nativeWriteEvent(tag, value);
-    }
+    public static native int writeEvent(int tag, int value);
 
     /**
      * Record an event log message.
@@ -348,13 +342,8 @@ public class EventLog {
      * @param value A value to log
      * @return The number of bytes written
      */
-    public static int writeEvent(int tag, long value) {
-        if (!Build.IS_DEBUGGABLE) {
-            return 0;
-        }
+    public static native int writeEvent(int tag, long value);
 
-        return nativeWriteEvent(tag, value);
-    }
 
     /**
      * Record an event log message.
@@ -362,13 +351,7 @@ public class EventLog {
      * @param value A value to log
      * @return The number of bytes written
      */
-    public static int writeEvent(int tag, float value) {
-        if (!Build.IS_DEBUGGABLE) {
-            return 0;
-        }
-
-        return nativeWriteEvent(tag, value);
-    }
+    public static native int writeEvent(int tag, float value);
 
     /**
      * Record an event log message.
@@ -376,13 +359,7 @@ public class EventLog {
      * @param str A value to log
      * @return The number of bytes written
      */
-    public static int writeEvent(int tag, String str) {
-        if (!Build.IS_DEBUGGABLE) {
-            return 0;
-        }
-
-        return nativeWriteEvent(tag, str);
-    }
+    public static native int writeEvent(int tag, String str);
 
     /**
      * Record an event log message.
@@ -390,13 +367,7 @@ public class EventLog {
      * @param list A list of values to log
      * @return The number of bytes written
      */
-    public static int writeEvent(int tag, Object... list) {
-        if (!Build.IS_DEBUGGABLE) {
-            return 0;
-        }
-
-        return nativeWriteEvent(tag, list);
-    }
+    public static native int writeEvent(int tag, Object... list);
 
     /**
      * Read events from the log, filtered by type.
@@ -404,14 +375,8 @@ public class EventLog {
      * @param output container to add events into
      * @throws IOException if something goes wrong reading events
      */
-    public static void readEvents(int[] tags, Collection<Event> output)
-            throws IOException {
-        if (!Build.IS_DEBUGGABLE) {
-            return;
-        }
-
-        nativeReadEvents(tags, output);
-    }
+    public static native void readEvents(int[] tags, Collection<Event> output)
+            throws IOException;
 
     /**
      * Read events from the log, filtered by type, blocking until logs are about to be overwritten.
@@ -422,29 +387,12 @@ public class EventLog {
      * @hide
      */
     @SystemApi
-    public static void readEventsOnWrapping(int[] tags, long timestamp,
+    public static native void readEventsOnWrapping(int[] tags, long timestamp,
             Collection<Event> output)
-            throws IOException {
-        if (!Build.IS_DEBUGGABLE) {
-            return;
-        }
-
-        nativeReadEventsOnWrapping(tags, timestamp, output);
-    }
+            throws IOException;
 
     // We assume that the native methods deal with any concurrency issues.
 
-    private static native int nativeWriteEvent(int tag, int value);
-    private static native int nativeWriteEvent(int tag, long value);
-    private static native int nativeWriteEvent(int tag, float value);
-    private static native int nativeWriteEvent(int tag, String str);
-    private static native int nativeWriteEvent(int tag, Object... list);
-
-    private static native void nativeReadEvents(int[] tags, Collection<Event> output)
-            throws IOException;
-    private static native void nativeReadEventsOnWrapping(int[] tags, long timestamp,
-            Collection<Event> output)
-            throws IOException;
 
     /**
      * Get the name associated with an event type tag code.

--- a/core/jni/android_util_EventLog.cpp
+++ b/core/jni/android_util_EventLog.cpp
@@ -68,16 +68,16 @@ static void android_util_EventLog_readEventsOnWrapping(JNIEnv* env, jobject claz
  */
 static const JNINativeMethod gRegisterMethods[] = {
     /* name, signature, funcPtr */
-    { "nativeWriteEvent", "(II)I", (void*) ELog::writeEventInteger },
-    { "nativeWriteEvent", "(IJ)I", (void*) ELog::writeEventLong },
-    { "nativeWriteEvent", "(IF)I", (void*) ELog::writeEventFloat },
-    { "nativeWriteEvent", "(ILjava/lang/String;)I", (void*) ELog::writeEventString },
-    { "nativeWriteEvent", "(I[Ljava/lang/Object;)I", (void*) ELog::writeEventArray },
-    { "nativeReadEvents",
+    { "writeEvent", "(II)I", (void*) ELog::writeEventInteger },
+    { "writeEvent", "(IJ)I", (void*) ELog::writeEventLong },
+    { "writeEvent", "(IF)I", (void*) ELog::writeEventFloat },
+    { "writeEvent", "(ILjava/lang/String;)I", (void*) ELog::writeEventString },
+    { "writeEvent", "(I[Ljava/lang/Object;)I", (void*) ELog::writeEventArray },
+    { "readEvents",
       "([ILjava/util/Collection;)V",
       (void*) android_util_EventLog_readEvents
     },
-    { "nativeReadEventsOnWrapping",
+    { "readEventsOnWrapping",
       "([IJLjava/util/Collection;)V",
       (void*) android_util_EventLog_readEventsOnWrapping
     },


### PR DESCRIPTION
Public API should not be modified in any case. 
There are actually apps using event log feature to perform black magic. For example, Brevent(https://play.google.com/store/apps/details?id=me.piebridge.brevent) checks event log to determine when apps are moved into background and kill them after some time accordingly.