### PR TITLE
Fix leaking receivers

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
@@ -308,7 +308,7 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable {
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
-        if (mAttached && !mEnabled) {
+        if (mAttached) {
             clearHandlerCallbacks();
             mContext.unregisterReceiver(mIntentReceiver);
             Dependency.get(TunerService.class).removeTunable(this);


### PR DESCRIPTION
Traffic monitor leaks receivers on each open of the QS panel. This in turn leads to SystemUI crash because 1000 receivers limit is reached.