### PR TITLE
Fix open/close menu action not working when assigned to navbar key

### DIFF
--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -3552,7 +3552,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                     }
                 }
 
-                return key_consumed;
+                break;
             case KeyEvent.KEYCODE_APP_SWITCH:
                 if (!keyguardOn) {
                     if (down && repeatCount == 0) {


### PR DESCRIPTION
When the "menu open/close" action is assigned to a navigation bar key, it fails to work due to the case returning "key_consumed" instead of continuing through like most other actions.