### PR TITLE
PixelPropUtils: Fix GMS drain triggered by an outdated ROM build date

### DIFF
--- a/core/java/com/android/internal/util/crdroid/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/crdroid/PixelPropsUtils.java
@@ -272,6 +272,7 @@ public class PixelPropsUtils {
                 setPropValue(key, value);
             }
             if (packageName.equals("com.google.android.gms")) {
+                setPropValue("TIME", System.currentTimeMillis());
                 final String processName = Application.getProcessName();
                 if (processName.toLowerCase().contains("unstable")
                     || processName.toLowerCase().contains("instrumentation")) {


### PR DESCRIPTION
If the build date exceeds a month, GMS, thinking the device is Pixel, attempts a system update, which unexpectedly fails. This goes into an endless cycle, which drains battery very quickly and generates a lot of heat. Let's fix it by spoofing the build date to something always fresh.