### PR TITLE
build: Don't check for fingerprint mismatch

### DIFF
--- a/core/java/android/os/Build.java
+++ b/core/java/android/os/Build.java
@@ -1305,7 +1305,7 @@ public class Build {
      */
     public static boolean isBuildConsistent() {
         // Don't care on eng builds.  Incremental build may trigger false negative.
-        if (IS_ENG) return true;
+        /*if (IS_ENG) return true;
 
         if (IS_TREBLE_ENABLED) {
             // If we can run this code, the device should already pass AVB.
@@ -1318,6 +1318,7 @@ public class Build {
             }
 
             return result == 0;
+            return true;
         }
 
         final String system = SystemProperties.get("ro.system.build.fingerprint");
@@ -1340,7 +1341,7 @@ public class Build {
                         + " but vendor reported " + vendor);
                 return false;
             }
-        }
+        } */
 
         /* TODO: Figure out issue with checks failing
         if (!TextUtils.isEmpty(bootimage)) {


### PR DESCRIPTION
* This removes the warning that sidplays at boot which states: "There is an internal problem with your device.  Contact the manufacturer for details"


Change-Id: I5515f204bcdbe0a792f95aa1ab321fe4a8fd2696