### PR TITLE
Rename removeAllProcessGroups() into removeAllEmptyProcessGroups()

### DIFF
--- a/core/jni/android_util_Process.cpp
+++ b/core/jni/android_util_Process.cpp
@@ -1245,7 +1245,7 @@ jint android_os_Process_sendSignalToProcessGroup(JNIEnv* env, jobject clazz, jin
 
 void android_os_Process_removeAllProcessGroups(JNIEnv* env, jobject clazz)
 {
-    return removeAllProcessGroups();
+    return removeAllEmptyProcessGroups();
 }
 
 static jint android_os_Process_nativePidFdOpen(JNIEnv* env, jobject, jint pid, jint flags) {


### PR DESCRIPTION
Make the function name match the function behavior.

Change-Id: I37b07fdd21d11ec9e19646bca5b2019a6e8e913a