### PR TITLE
Revert "Make dun APNs as read-only by default."

### DIFF
--- a/telephony/java/android/telephony/CarrierConfigManager.java
+++ b/telephony/java/android/telephony/CarrierConfigManager.java
@@ -10256,7 +10256,7 @@ public class CarrierConfigManager {
         sDefaults.putString(KEY_CI_ACTION_ON_SYS_UPDATE_EXTRA_VAL_STRING, "");
         sDefaults.putBoolean(KEY_CSP_ENABLED_BOOL, false);
         sDefaults.putBoolean(KEY_ALLOW_ADDING_APNS_BOOL, true);
-        sDefaults.putStringArray(KEY_READ_ONLY_APN_TYPES_STRING_ARRAY, new String[] {"dun"});
+        sDefaults.putStringArray(KEY_READ_ONLY_APN_TYPES_STRING_ARRAY, null);
         sDefaults.putStringArray(KEY_READ_ONLY_APN_FIELDS_STRING_ARRAY, null);
         sDefaults.putStringArray(KEY_APN_SETTINGS_DEFAULT_APN_TYPES_STRING_ARRAY, null);
         sDefaults.putAll(Apn.getDefaults());


### PR DESCRIPTION
This reverts commit fd528886c4dea4fe0a2a5d474ed8282d5f5058dc.

Carriers (esp in the US) should stop trying to lock us out of our own phones for no good reason.

If I need to fix broken carrier configs (like changing protocol) so that apps work correctly, I shouldn't lose the ability to recreate all APN types properly including "dun" for tethering.
_____

[This commit](https://github.com/crdroidandroid/android_frameworks_base/commit/fd528886c4dea4fe0a2a5d474ed8282d5f5058dc) was added 7 years ago as part of a patchset made to, essentially, make lazy carriers happy by restricting end-users from being able to add certain APN types to manually-created APNs.

The only type they've ever added to this restricted list in 7 years after implementing it is "dun", which is involved in hotspot/tethering.

Since not all mobile operators keep their carrier configs current with the AOSP team & platform vendors & ODM partners, we should be able to create/edit manual APN configs to correct things as needed, without losing the ability to use hotspot/tethering the same as with the built-in config.