### PR TITLE
fixup! Add option to toggle Google Play Integrity spoofing [1/2]

### DIFF
--- a/core/java/com/android/internal/util/crdroid/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/crdroid/PixelPropsUtils.java
@@ -443,6 +443,8 @@ public class PixelPropsUtils {
     }
 
     private static void spoofBuildGms() {
+        if (!SystemProperties.getBoolean(SPOOF_PIXEL_PI, true))
+            return;
         // Alter build parameters to avoid hardware attestation enforcement
         setPropValue("BRAND", "google");
         setPropValue("MANUFACTURER", "Google");


### PR DESCRIPTION
We should block spoofBuildGms alongside onEngineGetCertificateChain to ensure proper functionality of TrickyStore and Play Integrity Fix.
