### PR TITLE
Fix missing symbol in BatteryMeterViewControl…

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/battery/BatteryMeterViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/battery/BatteryMeterViewController.java
@@ -123,7 +123,8 @@ public class BatteryMeterViewController extends ViewController<BatteryMeterView>
     // Some places may need to show the battery conditionally, and not obey the tuner
     private boolean mIgnoreTunerUpdates;
     private boolean mIsSubscribedForTunerUpdates;
-
+    private boolean mBatteryHidden
+    
     @Inject
     public BatteryMeterViewController(
             BatteryMeterView view,


### PR DESCRIPTION
…ler.java

This fixes :

frameworks/base/packages/SystemUI/src/com/android/systemui/battery/BatteryMeterV iewController.java:118: error: cannot find symbol
mView.setVisibility(!batteryPresent || mBatteryHidden ^
symbol: variable mBatteryHidden