### PR TITLE
UDFPS: Make GhbmIlluminationListener interface public

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsSurfaceView.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsSurfaceView.java
@@ -41,7 +41,7 @@ public class UdfpsSurfaceView extends SurfaceView implements SurfaceHolder.Callb
     /**
      * Notifies {@link UdfpsView} when to enable GHBM illumination.
      */
-    interface GhbmIlluminationListener {
+    public interface GhbmIlluminationListener {
         /**
          * @param surface the surface for which GHBM should be enabled.
          * @param onDisplayConfigured a runnable that should be run after GHBM is enabled.


### PR DESCRIPTION
10-10 13:59:29.735  4516  4516 E AndroidRuntime: FATAL EXCEPTION: main
10-10 13:59:29.735  4516  4516 E AndroidRuntime: Process: com.android.systemui, PID: 4516
10-10 13:59:29.735  4516  4516 E AndroidRuntime: java.lang.IllegalAccessError: Interface com.android.systemui.biometrics.UdfpsSurfaceView$GhbmIlluminationListener implemented by class com.android.systemui.biometrics.ui.view.UdfpsTouchOverlay$configureDisplay$1 is inaccessible (declaration of 'com.android.systemui.biometrics.ui.view.UdfpsTouchOverlay$configureDisplay$1' appears in /system_ext/priv-app/SystemUI/SystemUI.apk!classes2.dex)