### PR TITLE
Allow signingInfo spoofing to bypass new Google checks

### DIFF
--- a/services/core/java/com/android/server/pm/ComputerEngine.java
+++ b/services/core/java/com/android/server/pm/ComputerEngine.java
@@ -170,6 +170,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1594,6 +1595,18 @@ public class ComputerEngine implements Computer {
 
             generateFakeSignature(p).ifPresent(fakeSignature -> {
                 packageInfo.signatures = new Signature[]{fakeSignature};
+                try {
+                    packageInfo.signingInfo = new SigningInfo(
+                            new SigningDetails(
+                                    packageInfo.signatures,
+                                    SigningDetails.SignatureSchemeVersion.SIGNING_BLOCK_V3,
+                                    SigningDetails.toSigningKeys(packageInfo.signatures),
+                                    null
+                            )
+                    );
+                } catch (CertificateException e) {
+                    Slog.e(TAG, "Caught an exception when creating signing keys: ", e);
+                }
             });
 
             return packageInfo;


### PR DESCRIPTION
Fixes https://github.com/microg/GmsCore/issues/2680 on crDroid
Google started checking not only `.signatures`, but also `.signingInfo`. Currently most Google applications aren't working with microG as Play Services replacement without this patch (YouTube, Maps, etc.)

Cherry picked from https://review.lineageos.org/c/LineageOS/android_frameworks_base/+/411374