### PR TITLE
Reduce ContrastColorUtil logspam

### DIFF
--- a/core/java/com/android/internal/util/ContrastColorUtil.java
+++ b/core/java/com/android/internal/util/ContrastColorUtil.java
@@ -791,9 +791,6 @@ public class ContrastColorUtil {
          */
         public static double calculateContrast(@ColorInt int foreground, @ColorInt int background) {
             if (Color.alpha(background) != 255) {
-                Log.w(TAG, String.format(
-                        "Background should not be translucent: #%s",
-                        Integer.toHexString(background)));
                 background = setAlphaComponent(background, 255);
             }
             if (Color.alpha(foreground) < 255) {


### PR DESCRIPTION
With version 10.12 there is this huge spam in log. It's fixed with this commit. Tested personally with logs.

04-07 18:44:52.867  1758  1758 W ContrastColorUtil: Background should not be translucent: #0
