### PR TITLE
Broadcast radio power state changes

### DIFF
--- a/services/core/java/com/android/server/TelephonyRegistry.java
+++ b/services/core/java/com/android/server/TelephonyRegistry.java
@@ -2723,6 +2723,7 @@ public class TelephonyRegistry extends ITelephonyRegistry.Stub {
             }
             handleRemoveListLocked();
         }
+        broadcastRadioPowerStateChanged(state, phoneId, subId);
     }
 
     @Override
@@ -3739,6 +3740,12 @@ public class TelephonyRegistry extends ITelephonyRegistry.Stub {
      */
     public static final String ACTION_SIGNAL_STRENGTH_CHANGED = "android.intent.action.SIG_STR";
 
+    /**
+     * Broadcast Action: The radio power state has changed.
+     */
+    private static final String ACTION_RADIO_POWER_STATE_CHANGED =
+            "org.codeaurora.intent.action.RADIO_POWER_STATE";
+
     private void broadcastServiceStateChanged(ServiceState state, int phoneId, int subId) {
         try {
             mBatteryStats.notePhoneState(state.getState());
@@ -3859,6 +3866,19 @@ public class TelephonyRegistry extends ITelephonyRegistry.Stub {
                 .setDeliveryGroupMatchingKey(Intent.ACTION_SERVICE_STATE,
                         subId + "-" + phoneId + "-" + tag)
                 .setDeferralPolicy(BroadcastOptions.DEFERRAL_POLICY_UNTIL_ACTIVE);
+    }
+
+    private void broadcastRadioPowerStateChanged(int state, int phoneId, int subId) {
+        Intent intent = new Intent(ACTION_RADIO_POWER_STATE_CHANGED);
+        intent.addFlags(Intent.FLAG_RECEIVER_INCLUDE_BACKGROUND);
+        // Pass the subscription along with the intent.
+        intent.putExtra(PHONE_CONSTANTS_SUBSCRIPTION_KEY, subId);
+        intent.putExtra(SubscriptionManager.EXTRA_SUBSCRIPTION_INDEX, subId);
+        intent.putExtra(PHONE_CONSTANTS_SLOT_KEY, phoneId);
+        intent.putExtra(SubscriptionManager.EXTRA_SLOT_INDEX, phoneId);
+        intent.putExtra(PHONE_CONSTANTS_STATE_KEY, state);
+        mContext.sendBroadcastAsUser(intent, UserHandle.ALL,
+                Manifest.permission.READ_PRIVILEGED_PHONE_STATE);
     }
 
     private void broadcastSignalStrengthChanged(SignalStrength signalStrength, int phoneId,


### PR DESCRIPTION
Broadcast an intent whenever there is any change in the current radio power state. BroadcastReceivers registering for this intent need to have READ_PRIVILEGED_PHONE_STATE permission in order to receive it.

Change-Id: Ie44cf4d0def60a1016dda705a7e347e33669976d
CRs-Fixed: 2838720