### PR TITLE
TelephonyManager fixes

### DIFF
--- a/telephony/java/android/telephony/TelephonyManager.java
+++ b/telephony/java/android/telephony/TelephonyManager.java
@@ -10124,7 +10124,8 @@ public class TelephonyManager {
             if (telephony != null) {
                 return telephony.getAllowedNetworkTypesForReason(getSubId(), reason);
             } else {
-                throw new IllegalStateException("telephony service is null.");
+                Rlog.d(TAG, "telephony service is null.");
+                return -1; // NETWORK_MODE_UNKNOWN
             }
         } catch (RemoteException ex) {
             Rlog.e(TAG, "getAllowedNetworkTypesForReason RemoteException", ex);

--- a/telephony/java/android/telephony/TelephonyManager.java
+++ b/telephony/java/android/telephony/TelephonyManager.java
@@ -19094,7 +19094,8 @@ public class TelephonyManager {
             if (telephony != null) {
                 return telephony.isNullCipherNotificationsEnabled();
             } else {
-                throw new IllegalStateException("telephony service is null.");
+                Log.d(TAG, "Telephony service is null.");
+                return false;
             }
         } catch (RemoteException ex) {
             Rlog.e(TAG, "isNullCipherNotificationsEnabled RemoteException", ex);

--- a/telephony/java/android/telephony/TelephonyManager.java
+++ b/telephony/java/android/telephony/TelephonyManager.java
@@ -14393,7 +14393,8 @@ public class TelephonyManager {
             if (service != null) {
                 return service.isDataEnabledForReason(subId, reason);
             } else {
-                throw new IllegalStateException("telephony service is null.");
+                Log.d(TAG, "Telephony service is null.");
+                return false;
             }
         } catch (RemoteException ex) {
             Log.e(TAG, "Telephony#isDataEnabledForReason RemoteException", ex);


### PR DESCRIPTION
This PR includes some fixes for TelephonyManager to fix crashes while e.g. trying to open "Settings->Network". This was seen on the MiPad4 device with Wifi only. The fixes were confirmed to work in the MiPad4 XDA [thread](https://xdaforums.com/t/rom-15-0-official-clover-kernelsu-crdroid-11-x-for-xiaomi-mi-pad-4-plus.4716611/).