### PR TITLE
ApplicationPackageManager: Allow Tensor features to Google Dialer

### DIFF
--- a/core/java/android/app/ApplicationPackageManager.java
+++ b/core/java/android/app/ApplicationPackageManager.java
@@ -927,7 +927,8 @@ public class ApplicationPackageManager extends PackageManager {
             if (Arrays.asList(featuresNexus).contains(name)) return true;
         }
         if (name != null && Arrays.asList(featuresTensor).contains(name)
-                && !Arrays.asList(pTensorCodenames).contains(SystemProperties.get("ro.product.device"))) {
+                && !Arrays.asList(pTensorCodenames).contains(SystemProperties.get("ro.product.device"))
+                && (packageName == null || !packageName.equals("com.google.android.dialer"))) {
             return false;
         }
         if (Arrays.asList(featuresPixel).contains(name)) return true;


### PR DESCRIPTION
This fixes the Googe Dialer incompatible toast msg after updating from the PlayStore