### PR TITLE
PixelPropsUtils: re-enable hardware attestation

### DIFF
--- a/core/java/com/android/internal/util/crdroid/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/crdroid/PixelPropsUtils.java
@@ -451,20 +451,4 @@ public final class PixelPropsUtils {
         }
         return content.toString();
     }
-
-    private static boolean isCallerSafetyNet() {
-        return Arrays.stream(Thread.currentThread().getStackTrace())
-                        .anyMatch(elem -> elem.getClassName().toLowerCase()
-                            .contains("droidguard"));
-    }
-
-    public static void onEngineGetCertificateChain() {
-        if (!SystemProperties.getBoolean(SPOOF_PIXEL_PI, true))
-            return;
-        // Check stack for SafetyNet or Play Integrity
-        if (isCallerSafetyNet() || sIsFinsky) {
-            Log.i(TAG, "Blocked key attestation");
-            throw new UnsupportedOperationException();
-        }
-    }
 }

--- a/keystore/java/android/security/keystore2/AndroidKeyStoreSpi.java
+++ b/keystore/java/android/security/keystore2/AndroidKeyStoreSpi.java
@@ -180,8 +180,6 @@ public class AndroidKeyStoreSpi extends KeyStoreSpi {
 
     @Override
     public Certificate[] engineGetCertificateChain(String alias) {
-        PixelPropsUtils.onEngineGetCertificateChain();
-
         KeyEntryResponse response = getKeyMetadata(alias);
 
         if (response == null || response.metadata.certificate == null) {


### PR DESCRIPTION
Remove the keystore exception blocking hardware attestation used for safetynet (dead) and legacy Play Integrity verdicts (dead A13+)

New A13+ verdicts require a hardware attest key for Basic Integrity, however the bootloader can be unlocked. By allowing hardware attestation and continuing to spoof beta props, devices with functioning TEE can pass basic and retain RCS functionality, as well as basic integrity for any apps requiring it (ChatGPT for example)

Tested on Pixel 5a (barbet), Pixel 5 (redfin) and Pixel Tablet (tangorpro)(unofficial)