### PR TITLE
SystemUI: Fix QS pulldown before first unlock

### DIFF
--- a/core/java/com/android/internal/app/LocaleStore.java
+++ b/core/java/com/android/internal/app/LocaleStore.java
@@ -32,6 +32,7 @@ import com.android.internal.annotations.VisibleForTesting;
 import java.io.Serializable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -615,7 +616,8 @@ public class LocaleStore {
         boolean hasTargetParent = parent != null;
         String parentId = hasTargetParent ? parent.getId() : null;
         HashSet<LocaleInfo> result = new HashSet<>();
-        for (LocaleStore.LocaleInfo li : supportedLocaleInfos.values()) {
+        Collection<LocaleInfo> currentLocaleInfos = new ArrayList<>(supportedLocaleInfos.values());
+        for (LocaleStore.LocaleInfo li : currentLocaleInfos) {
             if (isShallIgnore(ignorables, li, translatedOnly)) {
                 continue;
             }

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -27,7 +27,6 @@
     <!-- Do not translate. Defines the slots for the right-hand side icons.  That is to say, the
          icons in the status bar that are not notifications. -->
     <string-array name="config_statusBarIcons">
-        <item><xliff:g id="id">@string/status_bar_network_traffic</xliff:g></item>
         <item><xliff:g id="id">@string/status_bar_no_calling</xliff:g></item>
         <item><xliff:g id="id">@string/status_bar_call_strength</xliff:g></item>
         <item><xliff:g id="id">@string/status_bar_alarm_clock</xliff:g></item>
@@ -59,6 +58,7 @@
         <item><xliff:g id="id">@string/status_bar_cast</xliff:g></item>
         <item><xliff:g id="id">@string/status_bar_ethernet</xliff:g></item>
         <item><xliff:g id="id">@string/status_bar_oem_satellite</xliff:g></item>
+        <item><xliff:g id="id">@string/status_bar_network_traffic</xliff:g></item>
         <item><xliff:g id="id">@string/status_bar_wifi</xliff:g></item>
         <item><xliff:g id="id">@string/status_bar_hotspot</xliff:g></item>
         <item><xliff:g id="id">@string/status_bar_stacked_mobile</xliff:g></item>

--- a/packages/SystemUI/src/com/android/systemui/statusbar/NTForbiddenSwipeDownQSController.kt
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NTForbiddenSwipeDownQSController.kt
@@ -21,6 +21,8 @@ import android.net.Uri
 import android.os.Handler
 import android.os.UserHandle
 import android.provider.Settings
+import com.android.keyguard.KeyguardUpdateMonitor
+import com.android.keyguard.KeyguardUpdateMonitorCallback
 import com.android.systemui.SystemUIApplication
 import com.android.systemui.dagger.SysUISingleton
 import com.android.systemui.util.ScrimUtils
@@ -28,27 +30,43 @@ import javax.inject.Inject
 
 @SysUISingleton
 class NTForbiddenSwipeDownQSController @Inject constructor(
-    private val context: Context
+    private val context: Context,
+    private val keyguardUpdateMonitor: KeyguardUpdateMonitor
 ) : ScrimUtils.ScrimEventListener {
 
     private var enableSwipeDownQS: Int = ENABLE
     private var forbiddenSwipeDownQS: Boolean = false
     private var keyguardShowing: Boolean = false
+    private var userUnlocked: Boolean = false
     private var listening = false
 
+    private val keyguardUpdateMonitorCallback = object : KeyguardUpdateMonitorCallback() {
+        override fun onUserUnlocked() {
+            userUnlocked = true
+            updateForbiddenSwipeDownState()
+        }
+    }
+
     init {
+        // Initialize userUnlocked state from KeyguardUpdateMonitor
+        userUnlocked = keyguardUpdateMonitor.isUserUnlocked(UserHandle.USER_CURRENT)
+        
+        // Register callback to track when user unlocks
+        keyguardUpdateMonitor.registerCallback(keyguardUpdateMonitorCallback)
+        
         registerSettingsObserver()
         updateSettings()
     }
 
     fun getForbiddenSwipeDownQS(): Boolean = forbiddenSwipeDownQS
+
     fun setForbiddenSwipeDownQS(value: Boolean) {
         forbiddenSwipeDownQS = value
     }
 
     private fun registerSettingsObserver() {
-        context.contentResolver.registerContentObserver(Settings.Secure.getUriFor(
-            Settings.Secure.ENABLE_LOCKSCREEN_QUICK_SETTINGS),
+        context.contentResolver.registerContentObserver(
+            Settings.Secure.getUriFor(Settings.Secure.ENABLE_LOCKSCREEN_QUICK_SETTINGS),
             false,             
             object : ContentObserver(Handler()) {
                 override fun onChange(selfChange: Boolean, uri: Uri?) {
@@ -56,12 +74,18 @@ class NTForbiddenSwipeDownQSController @Inject constructor(
                     updateSettings()
                 }
             }, 
-            UserHandle.USER_ALL)
+            UserHandle.USER_ALL
+        )
     }
 
     private fun updateSettings() {
-        enableSwipeDownQS = Settings.Secure.getIntForUser(context.contentResolver,
-            Settings.Secure.ENABLE_LOCKSCREEN_QUICK_SETTINGS, ENABLE, UserHandle.USER_CURRENT)
+        enableSwipeDownQS = Settings.Secure.getIntForUser(
+            context.contentResolver,
+            Settings.Secure.ENABLE_LOCKSCREEN_QUICK_SETTINGS, 
+            ENABLE, 
+            UserHandle.USER_CURRENT
+        )
+        
         if (enableSwipeDownQS == DISABLE && !listening) {
             ScrimUtils.get().addListener(this)
             listening = true
@@ -69,11 +93,14 @@ class NTForbiddenSwipeDownQSController @Inject constructor(
             ScrimUtils.get().removeListener(this)
             listening = false
         }
+        
         updateForbiddenSwipeDownState()
     }
 
     private fun updateForbiddenSwipeDownState() {
-        forbiddenSwipeDownQS = keyguardShowing && enableSwipeDownQS == DISABLE
+        // Fix: Prevent QS pulldown before first unlock AND when keyguard is showing
+        // This resolves the race condition during Direct Boot (pre-unlock state)
+        forbiddenSwipeDownQS = (keyguardShowing || !userUnlocked) && enableSwipeDownQS == DISABLE
     }
     
     override fun onKeyguardShowingChanged(showing: Boolean) {
@@ -85,6 +112,7 @@ class NTForbiddenSwipeDownQSController @Inject constructor(
         private const val TAG = "ForbiddenSwipeDownQSController"
         private const val ENABLE = 1
         private const val DISABLE = 0
+
         @JvmStatic
         fun get(context: Context): NTForbiddenSwipeDownQSController {
             val app = context.applicationContext as SystemUIApplication

--- a/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
@@ -16,19 +16,18 @@
 
 package com.android.systemui.statusbar;
 
-import static com.android.systemui.statusbar.StatusBarIconView.STATE_DOT;
-import static com.android.systemui.statusbar.StatusBarIconView.STATE_HIDDEN;
 import static com.android.systemui.statusbar.StatusBarIconView.STATE_ICON;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.Rect;
-import android.graphics.drawable.Drawable;
 import android.graphics.PorterDuff;
 import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
 import android.net.ConnectivityManager;
 import android.net.LinkProperties;
 import android.net.Network;
@@ -50,14 +49,15 @@ import android.widget.TextView;
 
 import androidx.core.content.res.ResourcesCompat;
 
+import com.android.keyguard.KeyguardUpdateMonitor;
+import com.android.keyguard.KeyguardUpdateMonitorCallback;
 import com.android.systemui.Dependency;
 import com.android.systemui.res.R;
 import com.android.systemui.plugins.DarkIconDispatcher;
 import com.android.systemui.plugins.DarkIconDispatcher.DarkReceiver;
+import com.android.systemui.plugins.statusbar.StatusBarStateController;
 import com.android.systemui.statusbar.StatusIconDisplayable;
-import com.android.systemui.statusbar.phone.PhoneStatusBarPolicy.NetworkTrafficState;
-import com.android.keyguard.KeyguardUpdateMonitor;
-import com.android.keyguard.KeyguardUpdateMonitorCallback;
+import com.android.systemui.statusbar.StatusBarState;
 
 import com.android.systemui.tuner.TunerService;
 
@@ -115,8 +115,7 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
     private boolean mAutoHide;
     private long mAutoHideThreshold;
     private int mUnits;
-    private int mIconTint = 0;
-    private int newTint = Color.WHITE;
+    private int mTint = Color.WHITE;
 
     private Drawable mDrawable;
 
@@ -130,8 +129,8 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
     private ConnectivityManager mConnectivityManager;
     private final Handler mTrafficHandler;
 
-    private RelativeSizeSpan mSpeedRelativeSizeSpan = new RelativeSizeSpan(0.70f);
-    private RelativeSizeSpan mUnitRelativeSizeSpan = new RelativeSizeSpan(0.65f);
+    private RelativeSizeSpan mSpeedRelativeSizeSpan = new RelativeSizeSpan(0.68f);
+    private RelativeSizeSpan mUnitRelativeSizeSpan = new RelativeSizeSpan(0.63f);
 
     private boolean mEnabled = false;
     private boolean mConnectionAvailable = true;
@@ -142,12 +141,30 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
     private boolean mNetworksChanged = true;
 
     private int mVisibleState = -1;
-    private boolean mColorIsStatic;
 
     private KeyguardUpdateMonitor mKeyguardUpdateMonitor;
     private boolean mKeyguardShowing;
 
     private String mSlot;
+
+    private Configuration mConfiguration;
+    private boolean isLightMode;
+
+    private final StatusBarStateController mStatusBarStateController =
+            Dependency.get(StatusBarStateController.class);
+
+    private final StatusBarStateController.StateListener mStateListener =
+            new StatusBarStateController.StateListener() {
+        @Override
+        public void onStateChanged(int newState) {
+            onDarkChanged(new ArrayList<>(), 0f, mTint);
+        }
+
+        @Override
+        public void onExpandedChanged(boolean isExpanded) {
+            onDarkChanged(new ArrayList<>(), 0f, mTint);
+        }
+    };
 
     public NetworkTraffic(Context context) {
         this(context, null);
@@ -160,6 +177,9 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
     public NetworkTraffic(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
         mContext = context;
+        mConfiguration = new Configuration(context.getResources().getConfiguration());
+        isLightMode = (mConfiguration.uiMode & Configuration.UI_MODE_NIGHT_MASK)
+                == Configuration.UI_MODE_NIGHT_NO;
         mConnectivityManager =
                 (ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
         mTrafficHandler = new Handler(mContext.getMainLooper()) {
@@ -345,6 +365,9 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
     public static NetworkTraffic fromContext(Context context, String slot) {
         NetworkTraffic v = new NetworkTraffic(context);
         v.setSlot(slot);
+        v.setGravity(Gravity.CENTER);
+        int paddingHorizontal = (int) context.getResources().getDisplayMetrics().density;
+        v.setPadding(paddingHorizontal, 0, paddingHorizontal, 0);
         v.setVisibleState(STATE_ICON);
         return v;
     }
@@ -353,21 +376,39 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
         mSlot = slot;
     }
 
-    @Override
-    public void onDarkChanged(ArrayList<Rect> areas, float darkIntensity, int tint) {
-        if (mColorIsStatic) {
-            return;
-        }
-        newTint = DarkIconDispatcher.getTint(areas, this, tint);
-        checkUpdateTrafficDrawable();
+    private boolean isShadeInQs() {
+        return (mStatusBarStateController.isExpanded()
+                && mStatusBarStateController.getState() == StatusBarState.SHADE);
     }
 
     @Override
-    public void setStaticDrawableColor(int color) {
-        mColorIsStatic = true;
-        newTint = color;
-        checkUpdateTrafficDrawable();
+    protected void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        mConfiguration.setTo(newConfig);
+        isLightMode = (newConfig.uiMode & Configuration.UI_MODE_NIGHT_MASK)
+                == Configuration.UI_MODE_NIGHT_NO;
+        onDarkChanged(new ArrayList<>(), 0f, mTint);
     }
+
+    @Override
+    public void onDarkChanged(ArrayList<Rect> areas, float darkIntensity, int tint) {
+        if (isShadeInQs() && isLightMode) {
+            setTextColor(Color.BLACK);
+            if (mDrawable != null) {
+                mDrawable.setColorFilter(Color.BLACK, PorterDuff.Mode.MULTIPLY);
+            }
+            return;
+        }
+
+        mTint = DarkIconDispatcher.getTint(areas, this, tint);
+        setTextColor(mTint);
+        if (mDrawable != null) {
+            mDrawable.setColorFilter(mTint, PorterDuff.Mode.MULTIPLY);
+        }
+    }
+
+    @Override
+    public void setStaticDrawableColor(int color) {}
 
     @Override
     public void setDecorColor(int color) {
@@ -461,8 +502,12 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
             filter.addAction(ConnectivityManager.CONNECTIVITY_ACTION);
             mContext.registerReceiver(mIntentReceiver, filter, null, mTrafficHandler);
 
+            mStatusBarStateController.addCallback(mStateListener);
+
             mKeyguardUpdateMonitor = Dependency.get(KeyguardUpdateMonitor.class);
             mKeyguardUpdateMonitor.registerCallback(mUpdateCallback);
+
+            Dependency.get(DarkIconDispatcher.class).addDarkReceiver(this);
 
             updateViews();
         }
@@ -473,24 +518,18 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
         super.onDetachedFromWindow();
         if (mAttached) {
             clearHandlerCallbacks();
-            if (mKeyguardUpdateMonitor != null) {
-                mKeyguardUpdateMonitor.removeCallback(mUpdateCallback);
-                mKeyguardUpdateMonitor = null;
-            }
             mContext.unregisterReceiver(mIntentReceiver);
             mConnectivityManager.unregisterNetworkCallback(mDefaultNetworkCallback);
             mConnectivityManager.unregisterNetworkCallback(mNetworkCallback);
+            mStatusBarStateController.removeCallback(mStateListener);
+            mKeyguardUpdateMonitor.removeCallback(mUpdateCallback);
+            mKeyguardUpdateMonitor = null;
+            Dependency.get(DarkIconDispatcher.class).removeDarkReceiver(this);
             Dependency.get(TunerService.class).removeTunable(this);
             mDrawable = null;
             setCompoundDrawables(null, null, null, null);
             mAttached = false;
         }
-    }
-
-    public void applyNetworkTrafficState(NetworkTrafficState state) {
-        // mEnabled and state.visible will have same values, no need to set again
-        updateVisibility();
-        checkUpdateTrafficDrawable();
     }
 
     private final KeyguardUpdateMonitorCallback mUpdateCallback =
@@ -503,20 +542,13 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
             };
 
     private void updateVisibility() {
-        boolean visible = mEnabled && mIsActive && getText() != ""
-                    && !mKeyguardShowing 
-                    && mVisibleState == STATE_ICON;
+        boolean visible = mEnabled && mIsActive 
+                && !TextUtils.isEmpty(getText())
+                && !mKeyguardShowing
+                && mVisibleState == STATE_ICON;
         if (visible != mVisible) {
             mVisible = visible;
             setVisibility(mVisible ? View.VISIBLE : View.GONE);
-        }
-    }
-
-    private void checkUpdateTrafficDrawable() {
-        // Wait for icon to be visible and tint to be changed
-        if (mVisible && mIconTint != newTint) {
-            mIconTint = newTint;
-            updateTrafficDrawable();
         }
     }
 
@@ -623,28 +655,10 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
         }
         final Drawable drawable = mHideArrows ? null
             : ResourcesCompat.getDrawable(getResources(), drawableResId, getContext().getTheme());
-        if (mDrawable != drawable || mIconTint != newTint) {
+        if (mDrawable != drawable) {
             mDrawable = drawable;
-            mIconTint = newTint;
             setCompoundDrawablesRelativeWithIntrinsicBounds(null, null, mDrawable, null);
-            updateTrafficDrawable();
         }
-    }
-
-    public void setTint(int tint) {
-        newTint = tint;
-        // Wait for icon to be visible and tint to be changed
-        if (mVisible && mIconTint != newTint) {
-            mIconTint = newTint;
-            updateTrafficDrawable();
-        }
-    }
-
-    private void updateTrafficDrawable() {
-        if (mDrawable != null) {
-            mDrawable.setColorFilter(mIconTint, PorterDuff.Mode.MULTIPLY);
-        }
-        setTextColor(mIconTint);
     }
 
     private static class LinkPropertiesHolder {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
@@ -454,6 +454,17 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
                 }
 
                 @Override
+                public void onAvailable(Network network) {
+                    LinkProperties lp = mConnectivityManager == null ? null : 
+                        mConnectivityManager.getLinkProperties(network);
+                    if (lp != null && mTrafficHandler != null) {
+                        Message msg = Message.obtain(mTrafficHandler, MESSAGE_TYPE_ADD_NETWORK,
+                                new LinkPropertiesHolder(network, lp));
+                        mTrafficHandler.sendMessage(msg);
+                    }
+                }
+
+                @Override
                 public void onLost(Network network) {
                     if (mTrafficHandler != null) {
                         Message msg = new Message();

--- a/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
@@ -365,7 +365,6 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
     public static NetworkTraffic fromContext(Context context, String slot) {
         NetworkTraffic v = new NetworkTraffic(context);
         v.setSlot(slot);
-        v.setGravity(Gravity.CENTER);
         int paddingHorizontal = (int) context.getResources().getDisplayMetrics().density;
         v.setPadding(paddingHorizontal, 0, paddingHorizontal, 0);
         v.setVisibleState(STATE_ICON);
@@ -572,12 +571,17 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
                         TunerService.parseIntegerSwitch(newValue, false);
                 if (mEnabled) {
                     setLines(2);
+                    setMaxLines(2);
                     String txtFont = getResources().getString(com.android.internal.R.string.config_bodyFontFamily);
                     setTypeface(Typeface.create(txtFont, Typeface.BOLD));
                     setLineSpacing(0.80f, 0.80f);
                     setLayoutDirection(View.LAYOUT_DIRECTION_LOCALE);
                     setTextDirection(View.TEXT_DIRECTION_LOCALE);
-                    setTextAlignment(View.TEXT_ALIGNMENT_VIEW_START);
+                    setTextAlignment(View.TEXT_ALIGNMENT_VIEW_END);
+                    setGravity(Gravity.END | Gravity.CENTER_VERTICAL);
+                    setElegantTextHeight(false);
+                    setFontFeatureSettings("'tnum' 1");
+                    setIncludeFontPadding(false);
                 }
                 updateViews();
                 break;
@@ -611,11 +615,6 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
             case NETWORK_TRAFFIC_HIDEARROW:
                 mHideArrows =
                         TunerService.parseIntegerSwitch(newValue, false);
-                if (!mHideArrows) {
-                    setGravity(Gravity.END|Gravity.CENTER_VERTICAL);
-                } else {
-                    setGravity(Gravity.CENTER);
-                }
                 setTrafficDrawable();
                 break;
             default:

--- a/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
@@ -129,8 +129,11 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
     private ConnectivityManager mConnectivityManager;
     private final Handler mTrafficHandler;
 
-    private RelativeSizeSpan mSpeedRelativeSizeSpan = new RelativeSizeSpan(0.68f);
-    private RelativeSizeSpan mUnitRelativeSizeSpan = new RelativeSizeSpan(0.63f);
+    private final RelativeSizeSpan mSpeedRelativeSizeSpan = new RelativeSizeSpan(0.68f);
+    private final RelativeSizeSpan mUnitRelativeSizeSpan = new RelativeSizeSpan(0.63f);
+    private final DecimalFormat mDecimalFormat_0_2 = new DecimalFormat("0.##");
+    private final DecimalFormat mDecimalFormat_2_0 = new DecimalFormat("##0");
+    private final DecimalFormat mDecimalFormat_1_1 = new DecimalFormat("#0.#");
 
     private boolean mEnabled = false;
     private boolean mConnectionAvailable = true;
@@ -307,7 +310,6 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
             }
 
             private CharSequence formatOutput(long speed) {
-                DecimalFormat decimalFormat;
                 String unit;
                 String formatSpeed;
                 SpannableString spanUnitString;
@@ -328,32 +330,25 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
 
                 if (speed >= Giga) {
                     unit = gunit;
-                    decimalFormat = new DecimalFormat("0.##");
-                    formatSpeed = decimalFormat.format(speed / (float)Giga);
+                    formatSpeed = mDecimalFormat_0_2.format(speed / (float)Giga);
                 } else if (speed >= 100 * Mega) {
-                    decimalFormat = new DecimalFormat("##0");
                     unit = munit;
-                    formatSpeed = decimalFormat.format(speed / (float)Mega);
+                    formatSpeed = mDecimalFormat_2_0.format(speed / (float)Mega);
                 } else if (speed >= 10 * Mega) {
-                    decimalFormat = new DecimalFormat("#0.#");
                     unit = munit;
-                    formatSpeed = decimalFormat.format(speed / (float)Mega);
+                    formatSpeed = mDecimalFormat_1_1.format(speed / (float)Mega);
                 } else if (speed >= Mega) {
-                    decimalFormat = new DecimalFormat("0.##");
                     unit = munit;
-                    formatSpeed = decimalFormat.format(speed / (float)Mega);
+                    formatSpeed = mDecimalFormat_0_2.format(speed / (float)Mega);
                 } else if (speed >= 100 * Kilo) {
-                    decimalFormat = new DecimalFormat("##0");
                     unit = kunit;
-                    formatSpeed = decimalFormat.format(speed / (float)Kilo);
+                    formatSpeed = mDecimalFormat_2_0.format(speed / (float)Kilo);
                 } else if (speed >= 10 * Kilo) {
-                    decimalFormat = new DecimalFormat("#0.#");
                     unit = kunit;
-                    formatSpeed = decimalFormat.format(speed / (float)Kilo);
+                    formatSpeed = mDecimalFormat_1_1.format(speed / (float)Kilo);
                 } else {
-                    decimalFormat = new DecimalFormat("0.##");
                     unit = kunit;
-                    formatSpeed = decimalFormat.format(speed / (float)Kilo);
+                    formatSpeed = mDecimalFormat_0_2.format(speed / (float)Kilo);
                 }
                 spanSpeedString = new SpannableString(formatSpeed);
                 spanSpeedString.setSpan(mSpeedRelativeSizeSpan, 0, (formatSpeed).length(),

--- a/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
@@ -204,6 +204,9 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
                     case MESSAGE_TYPE_REMOVE_NETWORK:
                         mLinkPropertiesMap.remove((Network) msg.obj);
                         mNetworksChanged = true;
+                        mTxBytes = 0;
+                        mRxBytes = 0;
+                        displayStatsAndReschedule();
                         break;
                 }
             }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
@@ -25,7 +25,6 @@ import android.content.IntentFilter;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.Rect;
-import android.graphics.PorterDuff;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.net.ConnectivityManager;
@@ -48,6 +47,7 @@ import android.view.View;
 import android.widget.TextView;
 
 import androidx.core.content.res.ResourcesCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
 
 import com.android.keyguard.KeyguardUpdateMonitor;
 import com.android.keyguard.KeyguardUpdateMonitorCallback;
@@ -395,7 +395,7 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
         if (isShadeInQs() && isLightMode) {
             setTextColor(Color.BLACK);
             if (mDrawable != null) {
-                mDrawable.setColorFilter(Color.BLACK, PorterDuff.Mode.MULTIPLY);
+                DrawableCompat.setTint(mDrawable, Color.BLACK);
             }
             return;
         }
@@ -403,7 +403,7 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
         mTint = DarkIconDispatcher.getTint(areas, this, tint);
         setTextColor(mTint);
         if (mDrawable != null) {
-            mDrawable.setColorFilter(mTint, PorterDuff.Mode.MULTIPLY);
+            DrawableCompat.setTint(mDrawable, mTint);
         }
     }
 
@@ -655,6 +655,9 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
         }
         final Drawable drawable = mHideArrows ? null
             : ResourcesCompat.getDrawable(getResources(), drawableResId, getContext().getTheme());
+        if (drawable != null) {
+            DrawableCompat.setTint(drawable, mTint);
+        }
         if (mDrawable != drawable) {
             mDrawable = drawable;
             setCompoundDrawablesRelativeWithIntrinsicBounds(null, null, mDrawable, null);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
@@ -280,7 +280,7 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
                     }
 
                     // Update view if there's anything new to show
-                    if (output != getText()) {
+                    if (!TextUtils.equals(output, getText())) {
                         setText(output);
                     }
                 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NetworkTraffic.java
@@ -224,7 +224,9 @@ public class NetworkTraffic extends TextView implements TunerService.Tunable,
                 // Add interface stats, including stats from Clat's IPv4 interface
                 // (for applicable IPv6 networks). Stats are 0 if it doesn't exist.
                 final String[] ifaces = mLinkPropertiesMap.values().stream()
-                        .map(link -> link.getInterfaceName()).filter(iface -> iface != null)
+                        .map(LinkProperties::getInterfaceName)
+                        .filter(iface -> iface != null && !iface.isEmpty())
+                        .distinct()
                         .flatMap(iface -> Stream.of(iface, CLAT_PREFIX + iface))
                         .toArray(String[]::new);
                 for (String iface : ifaces) {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarPolicy.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarPolicy.java
@@ -362,7 +362,7 @@ public class PhoneStatusBarPolicy
         // network traffic
         mShowNetworkTraffic = Settings.System.getIntForUser(mContext.getContentResolver(),
             NETWORK_TRAFFIC_ENABLED, 0, UserHandle.USER_CURRENT) == 1;
-        updateNetworkTraffic();
+        mIconController.setNetworkTraffic(mSlotNetworkTraffic);
 
         mRotationLockController.addCallback(this);
         mBluetooth.addCallback(this);
@@ -610,8 +610,11 @@ public class PhoneStatusBarPolicy
     }
 
     private final void updateNetworkTraffic() {
-        mIconController.setNetworkTraffic(mSlotNetworkTraffic, new NetworkTrafficState(mShowNetworkTraffic));
-        mIconController.setIconVisibility(mSlotNetworkTraffic, mShowNetworkTraffic);
+        if (mShowNetworkTraffic) {
+            mIconController.setNetworkTraffic(mSlotNetworkTraffic);
+        } else {
+            mIconController.removeIcon(mSlotNetworkTraffic, 0);
+        }
     }
 
     private final void updateTTY() {
@@ -914,18 +917,5 @@ public class PhoneStatusBarPolicy
         }
 
         mIconController.setIconVisibility(mSlotConnectedDisplay, visible);
-    }
-
-    public static class NetworkTrafficState {
-        public boolean visible;
-
-        public NetworkTrafficState(boolean visible) {
-            this.visible = visible;
-        }
-
-        @Override
-        public String toString() {
-            return "NetworkTrafficState(visible=" + visible + ")";
-        }
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarIconHolder.kt
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarIconHolder.kt
@@ -17,7 +17,6 @@ package com.android.systemui.statusbar.phone
 
 import android.annotation.IntDef
 import com.android.internal.statusbar.StatusBarIcon
-import com.android.systemui.statusbar.phone.PhoneStatusBarPolicy.NetworkTrafficState
 import com.android.systemui.statusbar.pipeline.icons.shared.model.ModernStatusBarViewCreator
 
 /** Wraps [com.android.internal.statusbar.StatusBarIcon] so we can still have a uniform list */
@@ -67,12 +66,6 @@ open class StatusBarIconHolder private constructor() {
             " tag=$tag" +
             " visible=$isVisible)")
     }
-
-    var networkTrafficState: NetworkTrafficState? = null
-        get() = field
-        set(value) {
-            field = value
-        }
 
     companion object {
         const val TYPE_ICON = 0
@@ -146,10 +139,9 @@ open class StatusBarIconHolder private constructor() {
         }
 
         @JvmStatic
-        fun fromNetworkTrafficState(state: NetworkTrafficState): StatusBarIconHolder {
+        fun fromNetworkTraffic(): StatusBarIconHolder {
             val holder = StatusBarIconHolder()
             holder.type = TYPE_NETWORK_TRAFFIC
-            holder.networkTrafficState = state
             return holder
         }
     }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/ui/IconManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/ui/IconManager.java
@@ -48,7 +48,6 @@ import com.android.systemui.statusbar.StatusBarIconView;
 import com.android.systemui.statusbar.StatusIconDisplayable;
 import com.android.systemui.statusbar.connectivity.ui.MobileContextProvider;
 import com.android.systemui.statusbar.phone.DemoStatusIcons;
-import com.android.systemui.statusbar.phone.PhoneStatusBarPolicy.NetworkTrafficState;
 import com.android.systemui.statusbar.phone.StatusBarIconHolder;
 import com.android.systemui.statusbar.phone.StatusBarIconHolder.BindableIconHolder;
 import com.android.systemui.statusbar.phone.StatusBarLocation;
@@ -193,7 +192,7 @@ public class IconManager implements DemoModeCommandReceiver {
             case TYPE_ICON -> addIcon(index, slot, blocked, holder.getIcon());
             case TYPE_WIFI_NEW -> addNewWifiIcon(index, slot);
             case TYPE_MOBILE_NEW -> addNewMobileIcon(index, slot, holder.getTag());
-            case TYPE_NETWORK_TRAFFIC -> addNetworkTraffic(index, slot, holder.getNetworkTrafficState());
+            case TYPE_NETWORK_TRAFFIC -> addNetworkTraffic(index, slot);
             case TYPE_BINDABLE ->
                 // Safe cast, since only BindableIconHolders can set this tag on themselves
                     addBindableIcon((BindableIconHolder) holder, index);
@@ -260,9 +259,8 @@ public class IconManager implements DemoModeCommandReceiver {
         return view;
     }
 
-    private NetworkTraffic addNetworkTraffic(int index, String slot, NetworkTrafficState state) {
+    private NetworkTraffic addNetworkTraffic(int index, String slot) {
         NetworkTraffic view = onCreateNetworkTraffic(slot);
-        view.applyNetworkTrafficState(state);
         mGroup.addView(view, index, onCreateLayoutParams(Shape.WRAP_CONTENT));
         return view;
     }
@@ -366,18 +364,8 @@ public class IconManager implements DemoModeCommandReceiver {
             case TYPE_BINDABLE:
                 // Nothing, the new icons update themselves
                 return;
-            case TYPE_NETWORK_TRAFFIC:
-                onSetNetworkTraffic(viewIndex, holder.getNetworkTrafficState());
-                return;
             default:
                 break;
-        }
-    }
-
-    public void onSetNetworkTraffic(int viewIndex, NetworkTrafficState state) {
-        NetworkTraffic view = (NetworkTraffic) mGroup.getChildAt(viewIndex);
-        if (view != null) {
-            view.applyNetworkTrafficState(state);
         }
     }
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/ui/StatusBarIconController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/ui/StatusBarIconController.java
@@ -26,7 +26,6 @@ import androidx.annotation.DrawableRes;
 
 import com.android.internal.statusbar.StatusBarIcon;
 import com.android.systemui.res.R;
-import com.android.systemui.statusbar.phone.PhoneStatusBarPolicy.NetworkTrafficState;
 
 import java.util.List;
 
@@ -80,7 +79,7 @@ public interface StatusBarIconController {
     void setNewWifiIcon();
 
     /** */
-    void setNetworkTraffic(String slot, NetworkTrafficState state);
+    void setNetworkTraffic(String slot);
 
     /**
      * Notify this class that there is a new set of mobile icons to display, keyed off of this list

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/ui/StatusBarIconControllerImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/ui/StatusBarIconControllerImpl.java
@@ -45,7 +45,6 @@ import com.android.systemui.dump.DumpManager;
 import com.android.systemui.modes.shared.ModesUiIcons;
 import com.android.systemui.statusbar.CommandQueue;
 import com.android.systemui.statusbar.StatusIconDisplayable;
-import com.android.systemui.statusbar.phone.PhoneStatusBarPolicy.NetworkTrafficState;
 import com.android.systemui.statusbar.phone.StatusBarIconHolder;
 import com.android.systemui.statusbar.phone.StatusBarIconHolder.BindableIconHolder;
 import com.android.systemui.statusbar.pipeline.StatusBarPipelineFlags;
@@ -209,18 +208,12 @@ public class StatusBarIconControllerImpl implements Tunable,
     }
 
     @Override
-    public void setNetworkTraffic(String slot, NetworkTrafficState state) {
-        if (state == null) {
-            removeIcon(slot, 0);
-            return;
-        }
-
+    public void setNetworkTraffic(String slot) {
         StatusBarIconHolder holder = mStatusBarIconList.getIconHolder(slot, 0);
         if (holder == null) {
-            holder = StatusBarIconHolder.fromNetworkTrafficState(state);
+            holder = StatusBarIconHolder.fromNetworkTraffic();
             setIcon(slot, holder);
         } else {
-            holder.setNetworkTrafficState(state);
             handleSet(slot, holder);
         }
     }


### PR DESCRIPTION
On boot, the Quick Settings panel could be pulled down from the lock screen before the user's first unlock, even if the user had disabled QS on the lock screen. This was due to a race condition where the keyguard state was not yet fully initialized.

This change resolves the issue by injecting KeyguardUpdateMonitor into NTForbiddenSwipeDownQSController to track the user's unlock state. The controller now correctly identifies the Direct Boot (pre-unlock) state and forbids the QS pulldown until after the first unlock, respecting the user's setting from the moment the device boots.