### PR TITLE
haptics: Allow to set predefined feedback for texture tick effect

### DIFF
--- a/core/res/res/values/cr_config.xml
+++ b/core/res/res/values/cr_config.xml
@@ -95,4 +95,17 @@
 
     <!-- Whether to cancel fingerprint operation if not idle -->
     <bool name="config_fpCancelIfNotIdle">false</bool>
+
+    <!-- Vibrator pattern for feedback meant to replicate soft ticks (feels like texture underneath
+         the user's fingers), in gestures called repeatedly (such as dragging a slider thumb).
+
+         This is supposed to be used as a fallback pattern when hardware-specific implementation of
+         the effect does not exist, but it will still take over if the timings array is not empty.
+    -->
+    <integer-array name="config_textureTickVibePattern">
+        <!--
+        <item>0</item>
+        <item>10</item>
+        -->
+    </integer-array>
 </resources>

--- a/core/res/res/values/cr_symbols.xml
+++ b/core/res/res/values/cr_symbols.xml
@@ -76,4 +76,7 @@
 
     <!-- GameSpace -->
     <java-symbol type="string" name="gamespace_new_game_added" />
+
+    <!-- Vibrator service -->
+    <java-symbol type="array" name="config_textureTickVibePattern" />
 </resources>

--- a/services/core/java/com/android/server/vibrator/VibrationSettings.java
+++ b/services/core/java/com/android/server/vibrator/VibrationSettings.java
@@ -791,14 +791,16 @@ final class VibrationSettings {
                 com.android.internal.R.array.config_longPressVibePattern);
         VibrationEffect tickEffect = createEffectFromResource(resources,
                 com.android.internal.R.array.config_clockTickVibePattern);
+        VibrationEffect textureTickEffect = createEffectFromResource(resources,
+                com.android.internal.R.array.config_textureTickVibePattern);
 
         SparseArray<VibrationEffect> effects = new SparseArray<>();
         effects.put(VibrationEffect.EFFECT_CLICK, clickEffect);
         effects.put(VibrationEffect.EFFECT_DOUBLE_CLICK, doubleClickEffect);
         effects.put(VibrationEffect.EFFECT_TICK, tickEffect);
         effects.put(VibrationEffect.EFFECT_HEAVY_CLICK, heavyClickEffect);
-        effects.put(VibrationEffect.EFFECT_TEXTURE_TICK,
-                VibrationEffect.get(VibrationEffect.EFFECT_TICK, false));
+        effects.put(VibrationEffect.EFFECT_TEXTURE_TICK, textureTickEffect != null
+                ? textureTickEffect : VibrationEffect.get(VibrationEffect.EFFECT_TICK, false));
 
         return effects;
     }


### PR DESCRIPTION
Currently, the texture soft ticks will play only if there's a hardware-specific implementation. So, there may be no haptic feedback at all in actions called repeatedly (e.g., when dragging a slider thumb or when performing a back gesture). This is the case for most older devices, see [1].

This CL allows to configure the wave timings via overlay to replicate the texture tick effect implementation. The start & end time values may need to be tuned, so it's not too disruptive to the user.

NOTE: when set, this will ignore the hardware-specific implementation, if any (assuming none).

[1]: https://github.com/crdroidandroid/issue_tracker/issues/14