### PR TITLE
Only init vbmeta digest when Trickystore is configured

### DIFF
--- a/services/java/com/android/server/SystemServer.java
+++ b/services/java/com/android/server/SystemServer.java
@@ -1448,7 +1448,18 @@ public final class SystemServer implements Dumpable {
 
         t.traceBegin("InitVBMetaDigest");
         try {
-            android.security.trickystore.AttestationUtils.initBootHash();
+            final boolean hasTrickyStoreConfig =
+                    !TextUtils.isEmpty(Settings.Secure.getString(mSystemContext.getContentResolver(),
+                            Settings.Secure.SPOOF_TRICKYSTORE_TARGET))
+                    || !TextUtils.isEmpty(Settings.Secure.getString(mSystemContext.getContentResolver(),
+                            Settings.Secure.SPOOF_TRICKYSTORE_KEYBOX))
+                    || !TextUtils.isEmpty(Settings.Secure.getString(mSystemContext.getContentResolver(),
+                            Settings.Secure.SPOOF_TRICKYSTORE_PATCH));
+            if (hasTrickyStoreConfig) {
+                android.security.trickystore.AttestationUtils.initBootHash();
+            } else {
+                Slog.i(TAG, "Skipping VBMeta digest init; Trickystore spoofing is not configured");
+            }
         } catch (Throwable e) {
             Slog.e(TAG, "Failed to init VBMeta digest", e);
         }


### PR DESCRIPTION
Trickystore boot hash initialization currently runs unconditionally during SystemServer startup. On devices where Trickystore spoofing is not configured, this still triggers a temporary KeyStore attestation path and attempts to set ro.boot.vbmeta.digest, which is a bootloader property and is denied by SELinux.\n\nGate AttestationUtils.initBootHash() behind the existing Trickystore secure settings so the boot hash extraction path only runs when Trickystore target, keybox, or patch configuration is present.\n\nThis avoids unnecessary KeyStore/KeyMint work and noisy boot-time SELinux denial on devices not using the integrated Trickystore spoofing path.\n\nValidation:\n- repo sync frameworks/base\n- git diff --check crdroid/16.0...HEAD