### PR TITLE
crdroid: Add screen-on memory reclaim toggle

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -7408,6 +7408,14 @@ public final class Settings {
         public static final String POCKET_JUDGE = "pocket_judge";
 
         /**
+         * Whether to reclaim memory by killing cached apps shortly after screen on.
+         *   0 = disabled
+         *   1 = enabled
+         * @hide
+         */
+        public static final String SCREEN_ON_MEMORY_RECLAIM = "screen_on_memory_reclaim";
+
+        /**
          * Whether to show heads up only for dialer and sms apps
          * @hide
          */

--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -8247,6 +8247,10 @@ public class PhoneWindowManager implements WindowManagerPolicy {
     }
 
     private void releaseMemoryAtScreenOn() {
+        if (Settings.System.getIntForUser(mContext.getContentResolver(),
+                Settings.System.SCREEN_ON_MEMORY_RECLAIM, 1, UserHandle.USER_CURRENT) == 0) {
+            return;
+        }
         long currentTime = System.currentTimeMillis();
         if (lastMemoryReleaseTime == 0L || currentTime - lastMemoryReleaseTime > MEMORY_RELEASE_INTERVAL_MS) {
             try {


### PR DESCRIPTION
## Motivation

The screen-on memory reclaim is intrusive and frustrating to how I use my phone. Browsers reload their tabs whenever I pick my phone back up, and other apps crash or look broken when recalling them from recents.

I'd rather have less memory immediately available and rely on the usual memory management systems, than be greeted by dysfunctional or restarting recent apps.

## Changes

This PR adds a simple setting to toggle the screen-on memory reclaim feature.

Sibling PR for the settings app: https://github.com/crdroidandroid/android_packages_apps_crDroidSettings/pull/1330