### PR TITLE
services: Redact account names from sync security events

### DIFF
--- a/services/core/java/com/android/server/content/SyncStorageEngine.java
+++ b/services/core/java/com/android/server/content/SyncStorageEngine.java
@@ -1916,8 +1916,8 @@ public class SyncStorageEngine {
                         }
                     } else {
                         EventLog.writeEvent(0x534e4554, "35028827", -1,
-                                "account:" + info.account + " provider:" + authorityName + " user:"
-                                        + userId);
+                                "account:" + info.account.toSafeString()
+                                        + " provider:" + authorityName + " user:" + userId);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- redact account names from the SyncStorageEngine malformed-authority security event
- retain the account type, provider and user information needed for diagnostics

## Root cause

The event concatenated an `Account` object directly, implicitly calling
`Account.toString()`. That representation includes the complete account name and
can expose email addresses in the `events` log buffer before the first unlock.

Use the framework's canonical `Account.toSafeString()` representation instead.
It masks letters and digits in the account name while preserving useful
diagnostic context.

## Validation

- synchronized against the current crDroid 16.0 `frameworks/base`
- verified the change applies cleanly on commit `7581a03c7356`
- `git diff --check`
- confirmed `Account.toSafeString()` masks account-name letters and digits via
  `Account.toSafeName()`

Runtime confirmation requires a build containing this change.
