### PR TITLE
aapt2: support explicit IDs for private symbols

### DIFF
--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -6084,10 +6084,10 @@
   <java-symbol type="string" name="config_pluginsProviderJarPath" />
 
   <java-symbol type="bool" name="config_watchlistUseFileHashesCache" />
-  <java-symbol type="string" name="config_defaultContextualSearchPackageName" />
-  <java-symbol type="string" name="config_defaultContextualSearchKey" />
-  <java-symbol type="string" name="config_defaultContextualSearchEnabled" />
-  <java-symbol type="string" name="config_defaultContextualSearchLegacyEnabled" />
+  <java-symbol type="string" name="config_defaultContextualSearchPackageName" id="0x01040241" />
+  <java-symbol type="string" name="config_defaultContextualSearchKey" id="0x0104023f" />
+  <java-symbol type="string" name="config_defaultContextualSearchEnabled" id="0x0104023e" />
+  <java-symbol type="string" name="config_defaultContextualSearchLegacyEnabled" id="0x01040240" />
 
   <java-symbol type="string" name="unarchival_session_app_label" />
 

--- a/tools/aapt2/ResourceParser.cpp
+++ b/tools/aapt2/ResourceParser.cpp
@@ -1135,6 +1135,17 @@ bool ResourceParser::ParseSymbolImpl(xml::XmlPullParser* parser,
     return false;
   }
 
+  if (std::optional<StringPiece> maybe_id_str = xml::FindNonEmptyAttribute(parser, "id")) {
+    std::optional<ResourceId> maybe_id = ResourceUtils::ParseResourceId(maybe_id_str.value());
+    if (!maybe_id) {
+      diag_->Error(android::DiagMessage(out_resource->source)
+                   << "invalid resource ID '" << maybe_id_str.value() << "' in <"
+                   << parser->element_name() << "> tag");
+      return false;
+    }
+    out_resource->id = maybe_id.value();
+  }
+
   out_resource->name.type = parsed_type->ToResourceNamedType();
   return true;
 }

--- a/tools/aapt2/link/TableMerger.cpp
+++ b/tools/aapt2/link/TableMerger.cpp
@@ -107,10 +107,7 @@ static bool MergeEntry(IAaptContext* context, const android::Source& src, Resour
 
   // Copy over the strongest visibility.
   if (src_entry->visibility.level > dst_entry->visibility.level) {
-    // Only copy the ID if the source is public, or else the ID is meaningless.
-    if (src_entry->visibility.level == Visibility::Level::kPublic) {
-      dst_entry->id = src_entry->id;
-    }
+    dst_entry->id = src_entry->id;
     dst_entry->visibility = std::move(src_entry->visibility);
   } else if (src_entry->visibility.level == Visibility::Level::kPublic &&
              dst_entry->visibility.level == Visibility::Level::kPublic && dst_entry->id &&


### PR DESCRIPTION
Pixel Launcher expects `config_defaultContextualSearchPackageName` at resource ID `0x01040241`, but crDroid assigned that ID to `config_defaultContextualSearchLegacyEnabled`.

This caused Circle to Search availability checks to fail.

This change:

- Adds support for explicit IDs on private `<java-symbol>` resources.
- Preserves those IDs during AAPT2 table merging.
- Pins the contextual search resources to the IDs expected by Pixel Launcher.

