### PR TITLE
CachedAppOptimizer: skip unsupported system memcg compaction

### DIFF
--- a/services/core/java/com/android/server/am/CachedAppOptimizer.java
+++ b/services/core/java/com/android/server/am/CachedAppOptimizer.java
@@ -1868,6 +1868,9 @@ public class CachedAppOptimizer {
                     break;
                 }
                 case COMPACT_SYSTEM_MSG: {
+                    if (!profileValidForMemcg(CompactProfile.FULL)) {
+                        break;
+                    }
                     Trace.traceBegin(Trace.TRACE_TAG_ACTIVITY_MANAGER, "compactSystem");
                     long memFreedBefore = getMemoryFreedCompaction();
                     compactSystem();


### PR DESCRIPTION
## Summary

Skip global system compaction when the CompactFull memcg process profile is not supported.

## Problem

`compactSystem()` walks non-application processes and applies the `CompactFull`
process profile through `SetProcessProfiles()`.

On raphael with crDroid Android 16, the active kernel/cgroup layout does not
provide a usable `memory.reclaim` target for this profile. The global pass
therefore produces repeated failed cgroup operations.

Per-process compaction already checks `profileValidForMemcg()` and retains the
`process_madvise` fallback, but `COMPACT_SYSTEM_MSG` did not perform the same
validation.

## Change

Reuse the existing cached memcg profile validation before invoking
`compactSystem()`.

This does not disable or modify:

- per-process compaction
- the `process_madvise` fallback
- LMKD
- ZRAM
- Cached App Freezer

## Validation

Device: Xiaomi Mi 9T Pro / Redmi K20 Pro (`raphael`)

Build: crDroid Android 16, v12.11-20260623

An exact-build mitigation that bypasses only global `compactSystem()` removed
the repeated failed `CompactFull` / `memory.reclaim` operations while
per-process `am_compact` events remained functional.

Source build and device validation are still pending.

## Status

Draft pending compilation and validation on the affected device.